### PR TITLE
Fix kb/ to deepfield/ path inconsistency

### DIFF
--- a/plugin/agents/deepfield-knowledge-synth.md
+++ b/plugin/agents/deepfield-knowledge-synth.md
@@ -11,10 +11,10 @@ You are a knowledge synthesis specialist for the Deepfield knowledge base builde
 # Input
 
 You will receive:
-- **Current run findings** (`kb/wip/run-N/findings.md`)
-- **Existing drafts** (`kb/drafts/domains/<topic>.md`)
-- **Unknowns document** (`kb/drafts/cross-cutting/unknowns.md`)
-- **Changelog** (`kb/drafts/_changelog.md`)
+- **Current run findings** (`deepfield/wip/run-N/findings.md`)
+- **Existing drafts** (`deepfield/drafts/domains/<topic>.md`)
+- **Unknowns document** (`deepfield/drafts/cross-cutting/unknowns.md`)
+- **Changelog** (`deepfield/drafts/_changelog.md`)
 - **Confidence changes** (from learning plan updates)
 
 # Synthesis Tasks
@@ -25,7 +25,7 @@ When findings cover a topic with no existing draft:
 
 ### Create New Draft
 
-File: `kb/drafts/domains/<topic-name>.md`
+File: `deepfield/drafts/domains/<topic-name>.md`
 
 Structure:
 ```markdown
@@ -267,7 +267,7 @@ If topics split or merge, update all cross-references.
 
 ## 6. Update Unknowns Document
 
-Maintain `kb/drafts/cross-cutting/unknowns.md`:
+Maintain `deepfield/drafts/cross-cutting/unknowns.md`:
 
 ### Add New Unknowns
 
@@ -299,7 +299,7 @@ Group by type:
 
 ## 7. Append to Changelog
 
-Update `kb/drafts/_changelog.md` after each run:
+Update `deepfield/drafts/_changelog.md` after each run:
 
 ```markdown
 ## Run [N] - [Date]

--- a/plugin/agents/deepfield-learner.md
+++ b/plugin/agents/deepfield-learner.md
@@ -24,25 +24,25 @@ You will receive:
 Before deep reading, load relevant context:
 
 ### Previous Findings
-Read `kb/wip/run-N-1/findings.md` sections related to focus topics:
+Read `deepfield/wip/run-N-1/findings.md` sections related to focus topics:
 - What was already discovered?
 - What patterns were identified?
 - What questions were raised?
 
 ### Domain Notes
-If exist, read `kb/wip/domains/<domain>-notes.md`:
+If exist, read `deepfield/wip/domains/<domain>-notes.md`:
 - Previous understanding of this domain
 - Known patterns and relationships
 - Unresolved questions
 
 ### Current Drafts
-Read `kb/drafts/domains/<topic>.md`:
+Read `deepfield/drafts/domains/<topic>.md`:
 - Current state of documentation
 - Sections that exist vs gaps
 - Confidence markers and unknowns
 
 ### Open Questions
-From `kb/wip/learning-plan.md`, extract questions for focus topics:
+From `deepfield/wip/learning-plan.md`, extract questions for focus topics:
 - Guide deep reading toward answering these
 - Look for evidence supporting/refuting assumptions
 
@@ -184,7 +184,7 @@ Use format: `file-path:line-number` or `file-path:line-range`
 
 # Output Format
 
-Write findings to `kb/wip/run-N/findings.md`:
+Write findings to `deepfield/wip/run-N/findings.md`:
 
 ```markdown
 # Run [N] - Findings

--- a/plugin/commands/df-iterate.md
+++ b/plugin/commands/df-iterate.md
@@ -1,0 +1,132 @@
+---
+name: df-iterate
+description: Run autonomous learning iterations on the knowledge base
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Task
+arguments:
+  - name: --once
+    description: Run a single iteration instead of autonomous loop
+    required: false
+  - name: --focus
+    description: Focus on a specific domain (e.g. --focus=authentication)
+    required: false
+---
+
+# /df-iterate - Autonomous Learning Iterations
+
+Run learning iterations that read source code, synthesize knowledge, and update drafts. Continues autonomously until a stop condition is met, or runs once with `--once`.
+
+## Prerequisites
+
+Before running, verify ALL of the following:
+
+1. **deepfield/ directory exists** in the current working directory
+2. **Bootstrap (Run 0) is complete**: `deepfield/wip/run-0/` exists with a completed run config
+3. **Learning plan exists**: `deepfield/wip/learning-plan.md`
+4. **Project config exists**: `deepfield/project.config.json`
+
+If any prerequisite fails, display a clear error and suggest the correct command:
+- No `deepfield/`: "Run `/df-init` first"
+- No Run 0: "Run `/df-continue` or `/df-bootstrap` to complete bootstrap first"
+- No learning plan: "Bootstrap may have failed. Check `/df-status`"
+
+## State Validation
+
+```bash
+# Check deepfield directory
+if [ ! -d "./deepfield" ]; then
+  echo "No deepfield/ directory found. Run /df-init first."
+  exit 1
+fi
+
+# Check Run 0 completed
+if [ ! -f "./deepfield/wip/run-0/run-0.config.json" ]; then
+  echo "Bootstrap (Run 0) not complete. Run /df-continue first."
+  exit 1
+fi
+
+# Check learning plan
+if [ ! -f "./deepfield/wip/learning-plan.md" ]; then
+  echo "No learning plan found. Bootstrap may have failed. Check /df-status."
+  exit 1
+fi
+```
+
+## Execution
+
+After validation passes, invoke the **deepfield-iterate** skill with the following context:
+
+### Pass to Skill
+
+- **Mode**: autonomous (default) or single (`--once`)
+- **Focus domain**: value of `--focus` if provided, otherwise let skill select from learning plan
+- **Working directory**: current directory (where `deepfield/` lives)
+
+### Invoke Skill
+
+Delegate all learning logic to the `deepfield-iterate` skill. The skill handles:
+
+1. Determining the next run number
+2. Loading context from previous runs
+3. Selecting focus topics
+4. Incremental scanning
+5. Deep learning via learner agent
+6. Knowledge synthesis via synth agent
+7. Updating the learning plan
+8. Evaluating stop conditions
+9. Creating staging area on stop
+10. Reporting completion
+
+## Argument Handling
+
+### --once
+
+When `--once` is passed:
+- Tell the skill to run exactly one iteration
+- Skip stop condition evaluation
+- Always create staging area after the single run
+- Report single-run completion
+
+### --focus=DOMAIN
+
+When `--focus=domain` is passed:
+- Tell the skill to prioritize the specified domain
+- The skill should select topics related to that domain
+- Other topics may still be included if closely related
+
+## Output
+
+The command itself produces minimal output — just validation messages and then hands off to the skill. The skill produces the detailed progress and completion reports.
+
+### On Success
+
+```
+Invoking autonomous learning...
+
+[Skill takes over and produces detailed output]
+```
+
+### On Validation Failure
+
+```
+Cannot run iterations: [specific reason]
+
+[Suggestion for how to fix]
+```
+
+## Relationship to /df-continue
+
+`/df-continue` is the smart router that detects state and picks the right action. When it detects LEARNING state with new input, it effectively does what `/df-iterate` does. `/df-iterate` is the direct command for users who know they want to run iterations without state detection.
+
+## Tips for Claude
+
+- Always validate prerequisites before invoking the skill
+- If the user seems confused about workflow order, suggest `/df-continue` instead
+- After completion, suggest reviewing `deepfield/drafts/` for updated documentation
+- If stopped due to BLOCKED, highlight which sources are needed

--- a/plugin/scripts/clone-repos.sh
+++ b/plugin/scripts/clone-repos.sh
@@ -4,9 +4,9 @@
 # Usage: clone-repos.sh <repo-url> <destination> [branch|tag]
 #
 # Examples:
-#   clone-repos.sh https://github.com/org/repo ./kb/source/baseline/repos/repo
-#   clone-repos.sh https://github.com/org/repo ./kb/source/baseline/repos/repo main
-#   clone-repos.sh https://github.com/org/repo ./kb/source/baseline/repos/repo v1.0.0
+#   clone-repos.sh https://github.com/org/repo ./deepfield/source/baseline/repos/repo
+#   clone-repos.sh https://github.com/org/repo ./deepfield/source/baseline/repos/repo main
+#   clone-repos.sh https://github.com/org/repo ./deepfield/source/baseline/repos/repo v1.0.0
 
 set -euo pipefail
 

--- a/plugin/scripts/scaffold-kb.sh
+++ b/plugin/scripts/scaffold-kb.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# scaffold-kb.sh - Create complete kb/ directory structure with four-space architecture
+# scaffold-kb.sh - Create complete deepfield/ directory structure with four-space architecture
 # Usage: scaffold-kb.sh [target_dir]
-# Default target_dir: ./kb
+# Default target_dir: ./deepfield
 
 set -e
 
-# Use first argument as target, default to ./kb
-TARGET_DIR="${1:-./kb}"
+# Use first argument as target, default to ./deepfield
+TARGET_DIR="${1:-./deepfield}"
 
 # Get script directory for accessing template files
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -32,7 +32,7 @@ fi
 # Create four-space directory structure
 echo "Creating directory structure..."
 
-# Main kb/ directory
+# Main deepfield/ directory
 mkdir -p "$TARGET_DIR"
 
 # source/ - Raw inputs

--- a/plugin/skills/deepfield-bootstrap.md
+++ b/plugin/skills/deepfield-bootstrap.md
@@ -12,7 +12,7 @@ This skill orchestrates Run 0 (bootstrap) for the Deepfield knowledge base. It r
 # When to Use
 
 Invoke this skill when:
-- User has filled out `kb/source/baseline/brief.md`
+- User has filled out `deepfield/source/baseline/brief.md`
 - Project state is BRIEF_READY
 - No Run 0 has been executed yet
 - User runs `/df-continue` from BRIEF_READY state
@@ -20,16 +20,16 @@ Invoke this skill when:
 # Prerequisites
 
 Before running, verify:
-1. `kb/` directory exists (from `/df-init`)
-2. `kb/source/baseline/brief.md` exists and is filled out
-3. `kb/project.config.json` exists
-4. No `kb/wip/run-0/` directory exists (not already bootstrapped)
+1. `deepfield/` directory exists (from `/df-init`)
+2. `deepfield/source/baseline/brief.md` exists and is filled out
+3. `deepfield/project.config.json` exists
+4. No `deepfield/wip/run-0/` directory exists (not already bootstrapped)
 
 # Workflow
 
 ## Step 1: Read and Parse brief.md
 
-Read `kb/source/baseline/brief.md` to extract:
+Read `deepfield/source/baseline/brief.md` to extract:
 - Project name and description
 - Primary goal (onboarding, audit, decomposition, etc.)
 - Repository URLs with branches/tags
@@ -64,7 +64,7 @@ For each source listed in brief.md:
    ```bash
    ${CLAUDE_PLUGIN_ROOT}/scripts/clone-repos.sh \
      <repo-url> \
-     ./kb/source/baseline/repos/<repo-name> \
+     ./deepfield/source/baseline/repos/<repo-name> \
      <branch-or-tag>
    ```
 
@@ -86,14 +86,14 @@ For each source listed in brief.md:
    - Domains: Note suggestions
 
 3. **File documentation:**
-   - If trusted/reference → `kb/source/baseline/trusted-docs/`
-   - If exploratory → `kb/source/run-0/`
+   - If trusted/reference → `deepfield/source/baseline/trusted-docs/`
+   - If exploratory → `deepfield/source/run-0/`
 
 ### For User-Provided Context
 
 If brief includes meeting notes, tribal knowledge, or informal context:
 
-1. Save as markdown file in `kb/source/run-0/context.md`
+1. Save as markdown file in `deepfield/source/run-0/context.md`
 2. Classify as type "conversation", trust "exploratory"
 
 ## Step 3: Scan Project Structure
@@ -104,7 +104,7 @@ For each cloned repository:
    ```
    Launch: deepfield-scanner
    Input: {
-     "path": "./kb/source/baseline/repos/<repo-name>",
+     "path": "./deepfield/source/baseline/repos/<repo-name>",
      "context": <brief-context>
    }
    ```
@@ -117,7 +117,7 @@ For each cloned repository:
    - Key files (README, schemas, specs)
 
 3. **Write scan results:**
-   Save to `kb/wip/run-0/scan-<repo-name>.md`
+   Save to `deepfield/wip/run-0/scan-<repo-name>.md`
 
 ## Step 4: Detect Domains
 
@@ -139,11 +139,11 @@ Using all classification and scan results:
    - Identify suggested decompositions
 
 3. **Generate domain-index.md:**
-   Write structured domain index to `kb/wip/domain-index.md`
+   Write structured domain index to `deepfield/wip/domain-index.md`
 
 ## Step 5: Generate Initial Project Map
 
-Create high-level project map in `kb/wip/project-map.md`:
+Create high-level project map in `deepfield/wip/project-map.md`:
 
 ```markdown
 # Project Map
@@ -193,17 +193,17 @@ Run 1 will focus on: [HIGH priority topics from plan]
    - List needed sources
 
 3. **Write learning-plan.md:**
-   Save to `kb/wip/learning-plan.md`
+   Save to `deepfield/wip/learning-plan.md`
 
 ## Step 7: Create Run 0 Directory and Findings
 
 1. **Create directory structure:**
    ```bash
-   mkdir -p kb/wip/run-0/domains
+   mkdir -p deepfield/wip/run-0/domains
    ```
 
 2. **Write initial findings.md:**
-   Create `kb/wip/run-0/findings.md`:
+   Create `deepfield/wip/run-0/findings.md`:
    ```markdown
    # Run 0 - Bootstrap Findings
 
@@ -230,8 +230,8 @@ Run 1 will focus on: [HIGH priority topics from plan]
 1. **For each repository, compute hashes:**
    ```bash
    ${CLAUDE_PLUGIN_ROOT}/scripts/hash-files.js \
-     ./kb/source/baseline/repos/<repo-name> \
-     --output ./kb/wip/run-0/hashes-<repo-name>.json
+     ./deepfield/source/baseline/repos/<repo-name> \
+     --output ./deepfield/wip/run-0/hashes-<repo-name>.json
    ```
 
 2. **Merge all hashes into single object**
@@ -241,7 +241,7 @@ Run 1 will focus on: [HIGH priority topics from plan]
 
 ## Step 9: Write Run 0 Configuration
 
-Create `kb/wip/run-0/run-0.config.json`:
+Create `deepfield/wip/run-0/run-0.config.json`:
 
 ```json
 {
@@ -265,7 +265,7 @@ Use `${CLAUDE_PLUGIN_ROOT}/scripts/update-json.js` for atomic write.
 For each HIGH priority domain detected:
 
 1. **Create skeleton draft:**
-   Create `kb/drafts/domains/<domain-name>.md`:
+   Create `deepfield/drafts/domains/<domain-name>.md`:
    ```markdown
    # [Domain Name]
 
@@ -287,7 +287,7 @@ For each HIGH priority domain detected:
    ```
 
 2. **Update changelog:**
-   Append to `kb/drafts/_changelog.md`:
+   Append to `deepfield/drafts/_changelog.md`:
    ```markdown
    ## Run 0 - Bootstrap
 
@@ -298,7 +298,7 @@ For each HIGH priority domain detected:
 
 ## Step 11: Update Project Config
 
-Update `kb/project.config.json`:
+Update `deepfield/project.config.json`:
 
 ```json
 {
@@ -332,15 +332,15 @@ Display summary to user:
   Open Questions: [N]
 
 📁 Artifacts Created:
-  - kb/wip/project-map.md
-  - kb/wip/domain-index.md
-  - kb/wip/learning-plan.md
-  - kb/wip/run-0/findings.md
-  - kb/drafts/domains/[domain].md (skeletons)
+  - deepfield/wip/project-map.md
+  - deepfield/wip/domain-index.md
+  - deepfield/wip/learning-plan.md
+  - deepfield/wip/run-0/findings.md
+  - deepfield/drafts/domains/[domain].md (skeletons)
 
 🚀 Next Steps:
   Run /df-continue to start autonomous learning
-  Or add more sources to kb/source/run-1-staging/ first
+  Or add more sources to deepfield/source/run-1-staging/ first
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
@@ -350,7 +350,7 @@ Display summary to user:
 ## If brief.md not found
 
 ```
-Error: Brief not found at kb/source/baseline/brief.md
+Error: Brief not found at deepfield/source/baseline/brief.md
 
 Please run /df-start to generate the brief template, then fill it out
 with your project information before running bootstrap.
@@ -366,7 +366,7 @@ Bootstrap needs:
   - Primary goal selected
   - Focus areas indicated
 
-Please fill out kb/source/baseline/brief.md and try again.
+Please fill out deepfield/source/baseline/brief.md and try again.
 ```
 
 ## If repository clone fails

--- a/plugin/skills/deepfield-iterate.md
+++ b/plugin/skills/deepfield-iterate.md
@@ -21,7 +21,7 @@ Invoke this skill when:
 
 Before running, verify:
 1. Bootstrap complete (Run 0 exists)
-2. Learning plan exists (`kb/wip/learning-plan.md`)
+2. Learning plan exists (`deepfield/wip/learning-plan.md`)
 3. Project config has maxRuns setting
 4. Previous run completed successfully
 
@@ -47,7 +47,7 @@ While should_continue:
 
 ```javascript
 // Check existing runs
-const runs = glob('kb/wip/run-*/')
+const runs = glob('deepfield/wip/run-*/')
 const runNumbers = runs.map(r => parseInt(r.match(/run-(\d+)/)[1]))
 const nextRun = Math.max(...runNumbers) + 1
 ```
@@ -55,12 +55,12 @@ const nextRun = Math.max(...runNumbers) + 1
 ### 2. Create Run Directory
 
 ```bash
-mkdir -p kb/wip/run-${nextRun}/domains
+mkdir -p deepfield/wip/run-${nextRun}/domains
 ```
 
 ### 3. Initialize Run Config
 
-Create `kb/wip/run-${nextRun}/run-${nextRun}.config.json`:
+Create `deepfield/wip/run-${nextRun}/run-${nextRun}.config.json`:
 ```json
 {
   "runNumber": ${nextRun},
@@ -76,7 +76,7 @@ Create `kb/wip/run-${nextRun}/run-${nextRun}.config.json`:
 
 ### Read Learning Plan
 
-Load `kb/wip/learning-plan.md`:
+Load `deepfield/wip/learning-plan.md`:
 - Current confidence levels per topic
 - Open questions
 - Priorities
@@ -84,14 +84,14 @@ Load `kb/wip/learning-plan.md`:
 
 ### Read Previous Run
 
-Load `kb/wip/run-${nextRun-1}/run-${nextRun-1}.config.json`:
+Load `deepfield/wip/run-${nextRun-1}/run-${nextRun-1}.config.json`:
 - Previous file hashes
 - Focus topics
 - Confidence changes
 
 ### Check for New User Input
 
-Check if `kb/source/run-${nextRun}-staging/` exists with content:
+Check if `deepfield/source/run-${nextRun}-staging/` exists with content:
 - Read `feedback.md` if present
 - List new sources in `sources/` directory
 - Classify new sources via classifier agent
@@ -132,15 +132,15 @@ Learning plan has:
 For each baseline repository:
 ```bash
 ${CLAUDE_PLUGIN_ROOT}/scripts/hash-files.js \
-  ./kb/source/baseline/repos/<repo-name> \
-  --output ./kb/wip/run-${nextRun}/hashes-<repo-name>.json
+  ./deepfield/source/baseline/repos/<repo-name> \
+  --output ./deepfield/wip/run-${nextRun}/hashes-<repo-name>.json
 ```
 
 ### Compare with Previous Run
 
 ```javascript
-const prevHashes = readJSON(`kb/wip/run-${nextRun-1}/hashes-*.json`)
-const currHashes = readJSON(`kb/wip/run-${nextRun}/hashes-*.json`)
+const prevHashes = readJSON(`deepfield/wip/run-${nextRun-1}/hashes-*.json`)
+const currHashes = readJSON(`deepfield/wip/run-${nextRun}/hashes-*.json`)
 
 const changed = []
 const new_files = []
@@ -180,16 +180,16 @@ Launch: deepfield-learner
 Input: {
   "focus_topics": ["API Structure", "Data Flow"],
   "files_to_read": filesToRead,
-  "previous_findings": "kb/wip/run-${nextRun-1}/findings.md",
-  "domain_notes": "kb/wip/domains/*.md",
-  "current_drafts": "kb/drafts/domains/*.md",
+  "previous_findings": "deepfield/wip/run-${nextRun-1}/findings.md",
+  "domain_notes": "deepfield/wip/domains/*.md",
+  "current_drafts": "deepfield/drafts/domains/*.md",
   "open_questions": <from learning plan>
 }
 ```
 
 ### Process Learner Output
 
-Learner writes findings to `kb/wip/run-${nextRun}/findings.md`:
+Learner writes findings to `deepfield/wip/run-${nextRun}/findings.md`:
 - Discoveries about focus topics
 - Cross-references and relationships
 - Patterns observed
@@ -204,19 +204,19 @@ Learner writes findings to `kb/wip/run-${nextRun}/findings.md`:
 ```
 Launch: deepfield-knowledge-synth
 Input: {
-  "findings": "kb/wip/run-${nextRun}/findings.md",
-  "existing_drafts": "kb/drafts/domains/*.md",
-  "unknowns": "kb/drafts/cross-cutting/unknowns.md",
-  "changelog": "kb/drafts/_changelog.md"
+  "findings": "deepfield/wip/run-${nextRun}/findings.md",
+  "existing_drafts": "deepfield/drafts/domains/*.md",
+  "unknowns": "deepfield/drafts/cross-cutting/unknowns.md",
+  "changelog": "deepfield/drafts/_changelog.md"
 }
 ```
 
 ### Process Synthesis Output
 
 Synthesizer updates:
-- `kb/drafts/domains/<topic>.md` - Updated with new knowledge
-- `kb/drafts/cross-cutting/unknowns.md` - Add/remove unknowns
-- `kb/drafts/_changelog.md` - Append run summary
+- `deepfield/drafts/domains/<topic>.md` - Updated with new knowledge
+- `deepfield/drafts/cross-cutting/unknowns.md` - Add/remove unknowns
+- `deepfield/drafts/_changelog.md` - Append run summary
 
 ## Step 6: Update Learning Plan
 
@@ -247,7 +247,7 @@ If dependency discovered:
 
 ### Write Updated Plan
 
-Overwrite `kb/wip/learning-plan.md` with updated plan.
+Overwrite `deepfield/wip/learning-plan.md` with updated plan.
 
 ## Step 7: Finalize Run
 
@@ -368,17 +368,17 @@ When loop exits, create staging for next run:
 ### Create Directory Structure
 
 ```bash
-mkdir -p kb/source/run-${nextRun+1}-staging/sources
+mkdir -p deepfield/source/run-${nextRun+1}-staging/sources
 ```
 
 ### Copy Templates
 
 ```bash
 cp ${CLAUDE_PLUGIN_ROOT}/templates/staging-readme.md \
-   kb/source/run-${nextRun+1}-staging/README.md
+   deepfield/source/run-${nextRun+1}-staging/README.md
 
 cp ${CLAUDE_PLUGIN_ROOT}/templates/feedback.md \
-   kb/source/run-${nextRun+1}-staging/feedback.md
+   deepfield/source/run-${nextRun+1}-staging/feedback.md
 ```
 
 ### Populate Feedback Template
@@ -418,9 +418,9 @@ HIGH Priority Complete: [X]/[Y] topics >80%
 🔗 Contradictions Found: [N]
 
 📁 Documentation Updated:
-  - kb/drafts/domains/authentication.md
-  - kb/drafts/domains/api-structure.md
-  - kb/drafts/domains/data-flow.md
+  - deepfield/drafts/domains/authentication.md
+  - deepfield/drafts/domains/api-structure.md
+  - deepfield/drafts/domains/data-flow.md
 
 🔍 Next Steps:
 
@@ -437,11 +437,11 @@ HIGH Priority Complete: [X]/[Y] topics >80%
   ⏸️  Paused after [N] consecutive runs (max: [M])
 
   Please review:
-    - kb/drafts/ - Updated documentation
-    - kb/wip/learning-plan.md - Current state
+    - deepfield/drafts/ - Updated documentation
+    - deepfield/wip/learning-plan.md - Current state
 
   Add feedback or sources to:
-    kb/source/run-${nextRun+1}-staging/
+    deepfield/source/run-${nextRun+1}-staging/
 
   Then run /df-continue to continue learning
 
@@ -452,7 +452,7 @@ HIGH Priority Complete: [X]/[Y] topics >80%
     - [Topic]: Needs [specific sources]
 
   Please add to:
-    kb/source/run-${nextRun+1}-staging/sources/
+    deepfield/source/run-${nextRun+1}-staging/sources/
 
   Then run /df-continue
 
@@ -461,7 +461,7 @@ HIGH Priority Complete: [X]/[Y] topics >80%
 
   Suggestions:
     - Add new sources with different perspectives
-    - Review kb/drafts/cross-cutting/unknowns.md
+    - Review deepfield/drafts/cross-cutting/unknowns.md
     - Consider adjusting focus areas
     - Run /df-distill to snapshot current knowledge
 
@@ -470,7 +470,7 @@ HIGH Priority Complete: [X]/[Y] topics >80%
 
   Domain structure has changed significantly.
   Please review:
-    kb/wip/domain-index.md
+    deepfield/wip/domain-index.md
 
   Confirm new structure before continuing.
 


### PR DESCRIPTION
## Summary
- Replace all `kb/` path references with `deepfield/` across plugin skills, agents, and scripts
- Add `df-iterate` command entry point (thin wrapper invoking the iterate skill)
- Update scaffold script default target directory

Closes #2

## Test plan
- [ ] Verify no `kb/` references remain in plugin/ directory
- [ ] Verify df-iterate command has correct prerequisite checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)