### PR TITLE
feat: add Claude Code plugin marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,23 @@
+{
+  "name": "deepfield",
+  "owner": {
+    "name": "TomazWang"
+  },
+  "metadata": {
+    "description": "AI-driven knowledge base builder for understanding brownfield codebases"
+  },
+  "plugins": [
+    {
+      "name": "deepfield",
+      "source": "./plugin",
+      "description": "Iteratively learns your codebase and distills institutional knowledge. Provides df-* commands for autonomous knowledge base building.",
+      "author": {
+        "name": "TomazWang"
+      },
+      "homepage": "https://github.com/TomazWang/deepfield",
+      "repository": "https://github.com/TomazWang/deepfield",
+      "license": "MIT",
+      "keywords": ["knowledge-base", "brownfield", "documentation", "ai-assistant"]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -49,7 +49,18 @@ Or install locally in a project:
 npm install --save-dev deepfield
 ```
 
-### With Claude Code Plugin
+### With Claude Code Plugin (via Marketplace)
+
+The easiest way to install the Claude Code plugin:
+
+```
+/plugin marketplace add TomazWang/deepfield
+/plugin install deepfield@deepfield
+```
+
+That's it. The plugin is now available in Claude Code with all `df-*` commands.
+
+### With Claude Code Plugin (manual)
 
 1. **Install CLI** (see above)
 

--- a/openspec/changes/add-marketplace/.openspec.yaml
+++ b/openspec/changes/add-marketplace/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-03

--- a/openspec/changes/add-marketplace/design.md
+++ b/openspec/changes/add-marketplace/design.md
@@ -1,0 +1,39 @@
+## Context
+
+Deepfield is a Claude Code plugin hosted at `TomazWang/deepfield` on GitHub. The plugin lives in `./plugin/` with a valid `plugin.json`. Currently there is no `marketplace.json`, so users cannot install it via the Claude Code plugin system.
+
+The Claude Code marketplace spec requires a `.claude-plugin/marketplace.json` at the repo root. Once present, users can add the marketplace and install the plugin with two commands.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Enable installation via `/plugin marketplace add TomazWang/deepfield`
+- Enable plugin install via `/plugin install deepfield@deepfield`
+- Document installation in README
+
+**Non-Goals:**
+- Distributing via npm or pip
+- Multiple plugins in the marketplace (just `deepfield` for now)
+- Pinning to a specific ref/sha (latest main is fine)
+
+## Decisions
+
+**Marketplace name: `deepfield`**
+The marketplace name matches the plugin name. This keeps the install command simple: `deepfield@deepfield`. Alternative of `deepfield-marketplace` was rejected as redundant.
+
+**Plugin source: `"./plugin"`**
+The plugin code lives at `./plugin/` in the repo. Using a relative path works correctly because users add the marketplace via git (the whole repo is cloned), not via a direct URL to `marketplace.json`.
+
+**`strict` mode: default (true)**
+The plugin already has its own `plugin.json` at `./plugin/.claude-plugin/plugin.json`. Strict mode means that file is the authority. No need to override.
+
+**Version: not set in marketplace entry**
+Per docs: for plugins with their own `plugin.json`, set the version there (not in the marketplace entry) to avoid silent conflicts. The existing `plugin.json` already has `"version": "1.0.0"`.
+
+## Risks / Trade-offs
+
+- **Relative path only works with git-based install** → Acceptable; the repo is on GitHub and git-based install is the expected path. If URL-based distribution is needed later, switch sources to `{"source": "github", "repo": "TomazWang/deepfield"}`.
+
+## Open Questions
+
+None.

--- a/openspec/changes/add-marketplace/proposal.md
+++ b/openspec/changes/add-marketplace/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Users currently can't install Deepfield via the Claude Code plugin system — there's no marketplace catalog pointing to it. Adding a `marketplace.json` at the repo root lets anyone install with a single command: `/plugin marketplace add TomazWang/deepfield`.
+
+## What Changes
+
+- Add `.claude-plugin/marketplace.json` at the repository root, cataloging the `deepfield` plugin
+- The plugin source points to `./plugin` (the existing plugin directory)
+- Update README with installation instructions via marketplace
+
+## Capabilities
+
+### New Capabilities
+
+- `plugin-marketplace`: Marketplace catalog that enables Claude Code users to discover and install Deepfield via `/plugin marketplace add` and `/plugin install deepfield@deepfield`
+
+### Modified Capabilities
+
+## Impact
+
+- New file: `/.claude-plugin/marketplace.json`
+- Updated: `README.md` (add install instructions)
+- No changes to existing plugin code or behavior

--- a/openspec/changes/add-marketplace/specs/plugin-marketplace/spec.md
+++ b/openspec/changes/add-marketplace/specs/plugin-marketplace/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Marketplace catalog file exists
+The repository SHALL contain a `.claude-plugin/marketplace.json` file at the root that conforms to the Claude Code marketplace schema.
+
+#### Scenario: File exists at correct path
+- **WHEN** a user clones or inspects the repository root
+- **THEN** `.claude-plugin/marketplace.json` SHALL be present
+
+#### Scenario: Valid marketplace JSON
+- **WHEN** `claude plugin validate .` is run from the repo root
+- **THEN** the command SHALL succeed with no errors
+
+### Requirement: Marketplace catalogs the deepfield plugin
+The marketplace.json SHALL list the `deepfield` plugin with source pointing to `./plugin`.
+
+#### Scenario: Plugin is discoverable
+- **WHEN** a user adds the marketplace via `/plugin marketplace add TomazWang/deepfield`
+- **THEN** the `deepfield` plugin SHALL appear in the marketplace listing
+
+#### Scenario: Plugin is installable
+- **WHEN** a user runs `/plugin install deepfield@deepfield`
+- **THEN** Claude Code SHALL successfully install the plugin from `./plugin`
+
+### Requirement: README documents marketplace installation
+The repository README SHALL include instructions for installing via the marketplace.
+
+#### Scenario: Install instructions present
+- **WHEN** a user visits the repository README
+- **THEN** they SHALL find the `/plugin marketplace add` and `/plugin install` commands to install Deepfield

--- a/openspec/changes/add-marketplace/tasks.md
+++ b/openspec/changes/add-marketplace/tasks.md
@@ -1,0 +1,12 @@
+## 1. Marketplace File
+
+- [x] 1.1 Create `.claude-plugin/` directory at the repository root
+- [x] 1.2 Create `.claude-plugin/marketplace.json` with marketplace name `deepfield`, owner `TomazWang`, and the `deepfield` plugin entry pointing to `"./plugin"`
+
+## 2. Validation
+
+- [x] 2.1 Verify `claude plugin validate .` passes from the repo root (or manually confirm JSON is valid)
+
+## 3. Documentation
+
+- [x] 3.1 Add installation section to `README.md` with the two commands: `/plugin marketplace add TomazWang/deepfield` and `/plugin install deepfield@deepfield`

--- a/openspec/specs/plugin-marketplace/spec.md
+++ b/openspec/specs/plugin-marketplace/spec.md
@@ -1,0 +1,36 @@
+# Spec: plugin-marketplace
+
+## Purpose
+
+Defines requirements for the Claude Code marketplace catalog that enables users to discover and install the Deepfield plugin via the plugin system.
+
+## Requirements
+
+### Requirement: Marketplace catalog file exists
+The repository SHALL contain a `.claude-plugin/marketplace.json` file at the root that conforms to the Claude Code marketplace schema.
+
+#### Scenario: File exists at correct path
+- **WHEN** a user clones or inspects the repository root
+- **THEN** `.claude-plugin/marketplace.json` SHALL be present
+
+#### Scenario: Valid marketplace JSON
+- **WHEN** `claude plugin validate .` is run from the repo root
+- **THEN** the command SHALL succeed with no errors
+
+### Requirement: Marketplace catalogs the deepfield plugin
+The marketplace.json SHALL list the `deepfield` plugin with source pointing to `./plugin`.
+
+#### Scenario: Plugin is discoverable
+- **WHEN** a user adds the marketplace via `/plugin marketplace add TomazWang/deepfield`
+- **THEN** the `deepfield` plugin SHALL appear in the marketplace listing
+
+#### Scenario: Plugin is installable
+- **WHEN** a user runs `/plugin install deepfield@deepfield`
+- **THEN** Claude Code SHALL successfully install the plugin from `./plugin`
+
+### Requirement: README documents marketplace installation
+The repository README SHALL include instructions for installing via the marketplace.
+
+#### Scenario: Install instructions present
+- **WHEN** a user visits the repository README
+- **THEN** they SHALL find the `/plugin marketplace add` and `/plugin install` commands to install Deepfield


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/marketplace.json` at the repo root, enabling installation via the Claude Code plugin system
- Updates `README.md` with marketplace install instructions
- Adds OpenSpec change artifacts and main spec for `plugin-marketplace` capability

## Install (after merge)

```
/plugin marketplace add TomazWang/deepfield
/plugin install deepfield@deepfield
```

## Test plan

- [ ] Run `/plugin marketplace add TomazWang/deepfield` — marketplace should be added successfully
- [ ] Run `/plugin install deepfield@deepfield` — plugin should install from `./plugin`
- [ ] Verify `df-*` commands are available after install
- [ ] Confirm `claude plugin validate .` passes at repo root

🤖 Generated with [Claude Code](https://claude.com/claude-code)