### PR TITLE
feat: add CLI bootstrap command

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -43,11 +43,13 @@ program
 import { createInitCommand } from './commands/init.js';
 import { createStartCommand } from './commands/start.js';
 import { createStatusCommand } from './commands/status.js';
+import { createBootstrapCommand } from './commands/bootstrap.js';
 
 // Register commands
 program.addCommand(createInitCommand());
 program.addCommand(createStartCommand());
 program.addCommand(createStatusCommand());
+program.addCommand(createBootstrapCommand());
 
 // Global error handler
 process.on('uncaughtException', (error: Error) => {

--- a/cli/src/commands/bootstrap.ts
+++ b/cli/src/commands/bootstrap.ts
@@ -1,0 +1,175 @@
+import { Command } from 'commander';
+import { pathExists, readJson } from 'fs-extra';
+import { join } from 'path';
+import inquirer from 'inquirer';
+import chalk from 'chalk';
+import { StateError } from '../core/errors.js';
+
+// Internal type for prerequisite errors with suggestions
+interface PrerequisiteError {
+  message: string;
+  suggestion: string;
+}
+
+/**
+ * Create the bootstrap command
+ */
+export function createBootstrapCommand(): Command {
+  return new Command('bootstrap')
+    .description('Run initial bootstrap (Run 0) - classify sources, scan structure, detect domains')
+    .option('-f, --force', 'Skip confirmation prompts', false)
+    .option('-y, --yes', 'Answer yes to all prompts', false)
+    .option('--debug', 'Show debug output', false)
+    .action(async (options) => {
+      try {
+        await bootstrapCommand(options);
+        process.exit(0);
+      } catch (error) {
+        if (error instanceof BootstrapStateError) {
+          console.error(chalk.red('❌ Error:'), error.message);
+          console.error(chalk.yellow('\n💡 Suggestion:'), error.suggestion);
+          process.exit(3);
+        }
+        if (options.debug && error instanceof Error && error.stack) {
+          console.error(chalk.gray('\nStack trace:'));
+          console.error(chalk.gray(error.stack));
+        }
+        console.error(chalk.red('❌ Error:'), error instanceof Error ? error.message : String(error));
+        process.exit(1);
+      }
+    });
+}
+
+/**
+ * Extended StateError that carries a user-facing suggestion
+ */
+class BootstrapStateError extends StateError {
+  constructor(message: string, public readonly suggestion: string) {
+    super(message, 'MISSING');
+    this.name = 'BootstrapStateError';
+  }
+}
+
+/**
+ * Bootstrap command implementation
+ */
+async function bootstrapCommand(options: { force?: boolean; yes?: boolean; debug?: boolean }): Promise<void> {
+  const cwd = process.cwd();
+  const deepfieldDir = join(cwd, 'deepfield');
+
+  // 1. Validate prerequisites
+  await validatePrerequisites(deepfieldDir);
+
+  // 2. Show confirmation prompt (unless --yes or --force)
+  if (!options.yes && !options.force) {
+    const confirmed = await confirmBootstrap();
+    if (!confirmed) {
+      console.log(chalk.yellow('Bootstrap cancelled'));
+      return;
+    }
+  }
+
+  // 3. Run bootstrap
+  await runBootstrap(options);
+
+  // 4. Show completion
+  console.log(chalk.green('\n✅ Bootstrap (Run 0) completed!'));
+  console.log(chalk.blue('Next: Review findings in deepfield/wip/run-0/'));
+}
+
+/**
+ * Validate all prerequisites before running bootstrap
+ */
+async function validatePrerequisites(deepfieldDir: string): Promise<void> {
+  // Check deepfield/ directory exists
+  if (!(await pathExists(deepfieldDir))) {
+    throw new BootstrapStateError(
+      'deepfield/ directory not found',
+      'Run "deepfield init" first to create the directory structure'
+    );
+  }
+
+  // Check project.config.json exists and has non-empty projectName
+  const configPath = join(deepfieldDir, 'project.config.json');
+  if (!(await pathExists(configPath))) {
+    throw new BootstrapStateError(
+      'Project not configured',
+      'Run "deepfield start" to configure your project'
+    );
+  }
+
+  let config: Record<string, unknown>;
+  try {
+    config = await readJson(configPath);
+  } catch {
+    throw new BootstrapStateError(
+      'Project configuration is corrupted',
+      'Check deepfield/project.config.json for syntax errors'
+    );
+  }
+
+  if (!config.projectName || String(config.projectName).trim().length === 0) {
+    throw new BootstrapStateError(
+      'Project not configured',
+      'Run "deepfield start" to configure your project'
+    );
+  }
+
+  // Check deepfield/source/baseline/brief.md exists
+  const briefPath = join(deepfieldDir, 'source', 'baseline', 'brief.md');
+  if (!(await pathExists(briefPath))) {
+    throw new BootstrapStateError(
+      'Brief not found',
+      'Fill out deepfield/source/baseline/brief.md with your project details'
+    );
+  }
+
+  // Check Run 0 is not already completed
+  const run0ConfigPath = join(deepfieldDir, 'wip', 'run-0', 'run-0.config.json');
+  if (await pathExists(run0ConfigPath)) {
+    let run0Config: Record<string, unknown>;
+    try {
+      run0Config = await readJson(run0ConfigPath);
+    } catch {
+      // If it can't be read, assume not completed — allow bootstrap to proceed
+      return;
+    }
+    if (run0Config.status === 'completed') {
+      throw new BootstrapStateError(
+        'Bootstrap already completed',
+        'Use "deepfield iterate" or "deepfield continue" to continue learning'
+      );
+    }
+  }
+}
+
+/**
+ * Show what bootstrap will do and prompt for confirmation
+ */
+async function confirmBootstrap(): Promise<boolean> {
+  console.log(chalk.blue('\n📋 Bootstrap will:'));
+  console.log('  1. Read your project brief');
+  console.log('  2. Classify and organize sources');
+  console.log('  3. Scan project structure');
+  console.log('  4. Detect domains');
+  console.log('  5. Generate initial learning plan\n');
+
+  const { confirm } = await inquirer.prompt([
+    {
+      type: 'confirm',
+      name: 'confirm',
+      message: 'Continue with bootstrap?',
+      default: true,
+    },
+  ]);
+
+  return confirm;
+}
+
+/**
+ * Execute bootstrap logic (placeholder — Task 002 implements the actual skill)
+ */
+async function runBootstrap(_options: { force?: boolean; yes?: boolean; debug?: boolean }): Promise<void> {
+  console.log(chalk.yellow('\n⚠️  Bootstrap skill not yet implemented'));
+  console.log(chalk.blue('See Task 002 for full implementation'));
+}

--- a/openspec/changes/cli-bootstrap-command/.openspec.yaml
+++ b/openspec/changes/cli-bootstrap-command/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-04

--- a/openspec/changes/cli-bootstrap-command/design.md
+++ b/openspec/changes/cli-bootstrap-command/design.md
@@ -1,0 +1,39 @@
+## Context
+
+The Deepfield CLI is a Node.js/TypeScript command-line tool using Commander.js. It currently has `init`, `start`, and `status` commands. Each command follows the same pattern: a `create<Name>Command()` factory in `cli/src/commands/<name>.ts` that is registered in `cli/src/cli.ts`.
+
+The bootstrap command is the user-facing trigger for Run 0 — the initial AI-driven classification and scanning pass. It must validate that the project is in a ready state before invoking any AI work.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `deepfield bootstrap` command to the CLI
+- Validate all prerequisites before executing (deepfield dir, config, brief, Run 0 status)
+- Show a confirmation prompt describing what will happen (skippable with `--yes`)
+- Display clear error messages with actionable suggestions
+- Placeholder for the actual bootstrap skill (Task 002 wires in the AI)
+
+**Non-Goals:**
+- Implementing the actual bootstrap skill/AI logic (Task 002)
+- Modifying the plugin-side bootstrap skill
+- Adding support for partial or resumed bootstraps
+
+## Decisions
+
+**Decision: Follow existing command pattern**
+All commands use `create<Name>Command()` factory functions registered in `cli.ts`. Consistency beats cleverness — bootstrap follows the same pattern as `init`, `start`, `status`.
+
+**Decision: Use StateError from `core/errors.ts` (not `core/state.ts`)**
+`core/state.ts` exports its own `StateError` without a `suggestion` field. `core/errors.ts` exports the canonical `StateError`. The bootstrap command uses `core/errors.ts` errors to get proper exit codes and suggestion support from the global handler in `cli.ts`.
+
+**Decision: Placeholder for bootstrap execution**
+The `runBootstrap()` function logs a "not yet implemented" message and returns cleanly. This allows Task 001 to ship and unblock integration with Task 002, with no dummy logic that needs to be unwound later.
+
+**Decision: brief.md filled check via content length**
+Following the pattern in `start.ts`, we check that brief.md is not a blank template by looking at whether `projectName` in `project.config.json` is non-empty (populated by `deepfield start`), rather than parsing markdown.
+
+## Risks / Trade-offs
+
+- **Risk: StateError in `core/state.ts` vs `core/errors.ts` conflict** → Mitigation: Import only from `core/errors.ts` in the bootstrap command; do not import `StateError` from `core/state.ts`.
+- **Risk: Run 0 check is optimistic** → If `run-0.config.json` is missing, bootstrap is considered not-yet-done. This is correct behavior — absence of the file means not started.
+- **Risk: Placeholder message may confuse users** → Mitigation: Message explicitly says "Bootstrap skill not yet implemented" and references Task 002, making the state transparent.

--- a/openspec/changes/cli-bootstrap-command/proposal.md
+++ b/openspec/changes/cli-bootstrap-command/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The Deepfield CLI is missing a `bootstrap` command, causing users to get an "unknown command" error when they try to run `deepfield bootstrap`. The bootstrap command is the critical step that triggers Run 0 — the initial classification, scan, and domain detection that starts the knowledge-building process.
+
+## What Changes
+
+- New `bootstrap` command added to the Deepfield CLI (`deepfield bootstrap`)
+- Command validates prerequisites before executing (deepfield dir, project config, brief.md, Run 0 completion status)
+- Command shows confirmation prompt with what will happen (unless `--yes` flag used)
+- Command calls the bootstrap skill (or shows placeholder for Task 002)
+- `cli.ts` updated to register the new command
+
+## Capabilities
+
+### New Capabilities
+- `bootstrap-command`: CLI command that validates prerequisites and triggers the bootstrap skill (Run 0). Includes options `--force`, `--yes`, and `--debug`.
+
+### Modified Capabilities
+
+_(none — no existing spec-level behavior changes)_
+
+## Impact
+
+- **New file**: `cli/src/commands/bootstrap.ts`
+- **Modified file**: `cli/src/cli.ts` (registers the new command)
+- **Dependencies**: Uses existing `core/state.ts` (`readProjectConfig`), `core/errors.ts` (`StateError`), `inquirer`, `chalk`, `fs-extra`
+- **Exit codes**: 0 (success), 1 (general error), 2 (invalid args), 3 (state error), 4 (permission error)

--- a/openspec/changes/cli-bootstrap-command/specs/bootstrap-command/spec.md
+++ b/openspec/changes/cli-bootstrap-command/specs/bootstrap-command/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: Bootstrap command exists
+The CLI SHALL expose a `bootstrap` subcommand registered under the `deepfield` program.
+
+#### Scenario: Command is available
+- **WHEN** user runs `deepfield bootstrap --help`
+- **THEN** the CLI displays help text showing description, `--force`, `--yes`, and `--debug` options
+
+### Requirement: Prerequisite validation — deepfield directory
+Before executing bootstrap, the CLI SHALL verify the `deepfield/` directory exists in the current working directory.
+
+#### Scenario: Directory missing
+- **WHEN** user runs `deepfield bootstrap` without a `deepfield/` directory present
+- **THEN** CLI prints an error "deepfield/ directory not found", prints a suggestion to run `deepfield init`, and exits with code 3
+
+### Requirement: Prerequisite validation — project configuration
+The CLI SHALL verify that `deepfield/project.config.json` exists and contains a non-empty `projectName`.
+
+#### Scenario: Config missing or unconfigured
+- **WHEN** user runs `deepfield bootstrap` but `project.config.json` is absent or has no `projectName`
+- **THEN** CLI prints an error "Project not configured", prints a suggestion to run `deepfield start`, and exits with code 3
+
+### Requirement: Prerequisite validation — brief exists
+The CLI SHALL verify that `deepfield/source/baseline/brief.md` exists.
+
+#### Scenario: Brief file missing
+- **WHEN** user runs `deepfield bootstrap` but `brief.md` does not exist
+- **THEN** CLI prints an error "Brief not found", prints a suggestion to fill out the brief, and exits with code 3
+
+### Requirement: Prerequisite validation — Run 0 not completed
+The CLI SHALL verify that Run 0 has not already been completed (i.e., `deepfield/wip/run-0/run-0.config.json` does not exist with `status: "completed"`).
+
+#### Scenario: Bootstrap already done
+- **WHEN** user runs `deepfield bootstrap` but `run-0.config.json` exists with `status: "completed"`
+- **THEN** CLI prints an error "Bootstrap already completed", suggests using `deepfield iterate`, and exits with code 3
+
+### Requirement: Confirmation prompt
+Unless `--yes` or `--force` is provided, the CLI SHALL display a summary of what bootstrap will do and prompt the user to confirm before proceeding.
+
+#### Scenario: User confirms
+- **WHEN** user runs `deepfield bootstrap` and confirms the prompt
+- **THEN** CLI proceeds to execute bootstrap
+
+#### Scenario: User cancels
+- **WHEN** user runs `deepfield bootstrap` and declines the prompt
+- **THEN** CLI prints "Bootstrap cancelled" and exits with code 0
+
+#### Scenario: Skip with --yes
+- **WHEN** user runs `deepfield bootstrap --yes`
+- **THEN** CLI skips the confirmation prompt and proceeds directly
+
+### Requirement: Bootstrap execution placeholder
+When prerequisites pass and user confirms, the CLI SHALL invoke the bootstrap logic (currently a placeholder until Task 002).
+
+#### Scenario: Placeholder execution
+- **WHEN** all prerequisites pass and user confirms (or --yes is set)
+- **THEN** CLI prints a warning that bootstrap skill is not yet implemented and exits with code 0
+
+### Requirement: Error exit codes
+The CLI SHALL use consistent exit codes: 0 for success, 1 for general error, 2 for invalid arguments, 3 for state errors, 4 for permission errors.
+
+#### Scenario: State error exit code
+- **WHEN** any prerequisite check fails
+- **THEN** CLI exits with code 3

--- a/openspec/changes/cli-bootstrap-command/tasks.md
+++ b/openspec/changes/cli-bootstrap-command/tasks.md
@@ -1,0 +1,22 @@
+## 1. Create Bootstrap Command File
+
+- [x] 1.1 Create `cli/src/commands/bootstrap.ts` with `createBootstrapCommand()` factory function
+- [x] 1.2 Add `--force`, `--yes`, and `--debug` options to the command
+- [x] 1.3 Implement `validatePrerequisites()` — check deepfield/ directory exists
+- [x] 1.4 Implement `validatePrerequisites()` — check project.config.json exists and has non-empty projectName
+- [x] 1.5 Implement `validatePrerequisites()` — check deepfield/source/baseline/brief.md exists
+- [x] 1.6 Implement `validatePrerequisites()` — check Run 0 not already completed (run-0.config.json with status "completed")
+- [x] 1.7 Implement `confirmBootstrap()` — show what bootstrap will do and prompt for confirmation using inquirer
+- [x] 1.8 Implement `runBootstrap()` — placeholder that logs "not yet implemented" warning
+- [x] 1.9 Wire up action handler: validatePrerequisites → confirmBootstrap (unless --yes/--force) → runBootstrap → success message
+
+## 2. Register Command in CLI
+
+- [x] 2.1 Import `createBootstrapCommand` in `cli/src/cli.ts`
+- [x] 2.2 Call `program.addCommand(createBootstrapCommand())` in `cli/src/cli.ts`
+
+## 3. Error Handling
+
+- [x] 3.1 Ensure all StateErrors thrown in bootstrap.ts use `core/errors.ts` StateError (not core/state.ts)
+- [x] 3.2 Verify exit code 3 is used for all prerequisite failures (StateError has exitCode 3)
+- [x] 3.3 Verify cancellation exits with code 0 cleanly


### PR DESCRIPTION
## Summary
- Adds `deepfield bootstrap` CLI command (Run 0 trigger) per TASK-001
- Validates prerequisites: deepfield/ dir, project.config.json, brief.md, Run 0 not already completed
- Shows confirmation prompt with what will happen (skippable with `--yes` or `--force`)
- Clear error messages with actionable suggestions and exit code 3 for state errors
- Placeholder `runBootstrap()` for Task 002 to wire in the actual skill

## Files Changed
- **New**: `cli/src/commands/bootstrap.ts` — full bootstrap command implementation
- **Modified**: `cli/src/cli.ts` — registers the bootstrap command
- **New**: `openspec/changes/cli-bootstrap-command/` — OpenSpec artifacts (proposal, design, specs, tasks)

## Test plan
- [ ] `deepfield bootstrap --help` shows correct description and options
- [ ] Run without `deepfield/` dir → error "deepfield/ directory not found" + suggestion, exit 3
- [ ] Run after `deepfield init` (no start) → error "Project not configured" + suggestion, exit 3
- [ ] Run after `deepfield start` without brief.md → error "Brief not found" + suggestion, exit 3
- [ ] Run with valid setup → shows confirmation prompt with 5-step plan
- [ ] Confirm → prints "not yet implemented" warning, exits 0
- [ ] Cancel → prints "Bootstrap cancelled", exits 0
- [ ] `deepfield bootstrap --yes` → skips prompt, runs directly
- [ ] After `run-0.config.json` with `status: "completed"` exists → error "Bootstrap already completed", exit 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)