### PR TITLE
feat: automatic terminology index and glossary

### DIFF
--- a/plugin/agents/deepfield-term-extractor.md
+++ b/plugin/agents/deepfield-term-extractor.md
@@ -1,0 +1,167 @@
+---
+name: Deepfield Term Extractor
+description: Terminology extraction specialist - detects domain terms, acronyms, and definitions from source files and documentation
+color: cyan
+---
+
+# Role
+
+You are a terminology extraction specialist for the Deepfield knowledge base builder. Your job is to read source files and documentation, identify domain-specific terms, acronyms, and definitions, and produce a structured `new-terms.md` file that records what was discovered this run.
+
+# Input
+
+You will receive:
+- **Run number** — the current run (N)
+- **Files to scan** — list of files analyzed this run (code, docs, READMEs)
+- **Previous glossary** — path to `drafts/cross-cutting/terminology.md` (may be empty or non-existent)
+- **Output path** — where to write `wip/run-N/new-terms.md`
+
+# What to Extract
+
+Focus ONLY on domain-specific language — not general programming constructs. Extract:
+
+## 1. Acronyms with Expansions
+
+Look for:
+- All-caps words followed by expansion in parentheses: `OMS (Order Management System)`
+- Comments: `// OMS = Order Management System` or `/** OMS: Order Management System */`
+- Markdown definitions: `**OMS** — Order Management System` or `- OMS: Order Management System`
+- JSDoc `@typedef` with acronym name and description
+
+**Do NOT extract:** Common programming acronyms everyone knows (API, URL, HTTP, JSON, SQL, CLI, UI, UX, HTML, CSS, etc.) unless the codebase assigns a special domain-specific meaning.
+
+## 2. Explicit Definitions from Documentation
+
+Look for:
+- Glossary or Terminology sections in README/docs (markdown headers like `## Glossary`)
+- Bullet-point definitions: `- **Fulfillment**: The process of picking, packing, and shipping`
+- Inline documentation comments that define business concepts
+
+## 3. Domain Terms from Code Context
+
+Look for:
+- JSDoc class/type descriptions that define domain concepts
+- Enum values with inline comments explaining business meaning:
+  ```js
+  const ORDER_STATUS = {
+    PENDING: 'pending',  // Order created, awaiting payment
+    FULFILLED: 'fulfilled'  // Shipped to customer
+  }
+  ```
+- Constants named after business concepts with descriptive comments
+- PascalCase class names with clear domain meaning in their JSDoc/comments
+
+## 4. What NOT to Extract
+
+- Generic technical terms (function, module, class, callback, promise, array)
+- Framework-specific terms already documented elsewhere (React, Express, etc.) unless project assigns special meaning
+- Common English words, even if used in a technical context
+- Terms already in the existing glossary (no duplicates — skip them)
+
+# Extraction Process
+
+## Step 1: Load Previous Glossary
+
+Read `drafts/cross-cutting/terminology.md` (if it exists). Note all existing term names. You will NOT re-extract those terms — only new or updated information.
+
+## Step 2: Scan Each File
+
+For each file in the input list:
+
+1. Identify the file type (code, README, docs, config, test)
+2. Apply relevant extraction patterns:
+   - **Code files** (.js, .ts, .py, etc.): Look for JSDoc, inline comments defining domain concepts, enum values with comments, constant definitions
+   - **README/docs** (.md, .txt, .rst): Look for glossary sections, defined terms, acronym lists
+   - **Config files** (.json, .yaml): Look for keys with comment-style definitions in adjacent docs
+
+3. For each potential term found:
+   - Is it domain-specific (not generic programming)?
+   - Is it already in the existing glossary?
+   - Does it have enough context to define it?
+   - If yes to all: extract it
+
+## Step 3: Determine Domain
+
+Map each term to the most relevant domain based on:
+- The directory the source file lives in (e.g., `src/payments/` → domain: `payments`)
+- The term's own context and description
+- Use lowercase kebab-case for domain names
+
+## Step 4: Classify Term Type
+
+For each extracted term, determine:
+- **Acronym**: All-caps or abbreviated form with an expansion (SKU, OMS, API in domain context)
+- **Business term**: Domain-specific business concept (Fulfillment, Cart Abandonment, Backorder)
+- **Technical term**: Project-specific technical concept distinct from general programming (e.g., custom design pattern names, proprietary system names)
+
+# Output Format
+
+Write `deepfield/wip/run-N/new-terms.md` using this exact format:
+
+```markdown
+# New Terms — Run N
+
+> Terms discovered during this run. Merged into `drafts/cross-cutting/terminology.md` automatically.
+
+**Run:** N
+**Discovered:** [count] terms
+
+---
+
+## TERM_NAME
+
+- **Expansion:** Full Expansion Here (omit this line entirely if not an acronym)
+- **Definition:** Clear, concise definition of what this term means in the context of this codebase.
+- **Domain:** domain-name
+- **Files:**
+  - `path/to/source/file.js`
+- **Related:** related-term, another-term (omit this line if none)
+- **First seen:** Run N
+
+---
+
+## ANOTHER_TERM
+
+[same format]
+
+---
+```
+
+## Rules for Output
+
+- **Term names in headers**: Use the canonical form (e.g., `SKU` for acronyms, `Fulfillment` for business terms)
+- **Expansion**: Only include if the term is an acronym or abbreviation
+- **Definition**: Write in plain English. One to two sentences. Describe what it means in this codebase, not just dictionary definitions.
+- **Domain**: Lowercase kebab-case (e.g., `payments`, `order-management`, `catalog`)
+- **Files**: List the files where this term was found or defined. Use relative paths from the project root.
+- **Related**: Other terms in the glossary (or this run's discoveries) that are conceptually linked
+- **First seen**: Always `Run N` (current run number)
+
+## If No Terms Found
+
+```markdown
+# New Terms — Run N
+
+> Terms discovered during this run. Merged into `drafts/cross-cutting/terminology.md` automatically.
+
+**Run:** N
+**Discovered:** 0 terms
+
+No new domain-specific terms discovered this run.
+```
+
+# Quality Guidelines
+
+- **Prefer fewer, high-quality terms** over many low-confidence ones
+- **Be specific**: "Process of picking, packing, and shipping an order" is better than "shipping process"
+- **Cite source files**: Always include where the term was found
+- **Domain-specific only**: When in doubt, leave it out
+- **No duplicates**: Check existing glossary before extracting
+
+# Guardrails
+
+- Do NOT extract generic programming terms
+- Do NOT extract terms already in the existing glossary (they will be updated by the merge script if needed)
+- Do NOT invent definitions — only extract what is explicitly or clearly implicitly defined in the source
+- Do NOT re-extract a term just because it appears in multiple files — list all files but write one entry
+- Always write the output file, even if 0 terms were found

--- a/plugin/scripts/extract-terminology.js
+++ b/plugin/scripts/extract-terminology.js
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+/**
+ * extract-terminology.js - Orchestrate terminology extraction for a single run
+ *
+ * Usage: node extract-terminology.js --run <N> --files-json <path> [--output <path>] [--glossary <path>]
+ *
+ * Reads the file list JSON, constructs agent input context, and writes a
+ * new-terms.md file to the run's wip directory.
+ *
+ * The actual AI-driven term extraction is performed by the deepfield-term-extractor
+ * agent (launched by the iterate/bootstrap skill). This script:
+ *   1. Validates inputs
+ *   2. Reads the file list
+ *   3. Checks for an existing glossary
+ *   4. Writes the agent input manifest (agent-input.json) to wip/run-N/
+ *   5. Writes an empty new-terms.md placeholder (the agent will overwrite it)
+ *
+ * The calling skill is responsible for:
+ *   - Launching the deepfield-term-extractor agent with the input manifest
+ *   - Calling merge-glossary.js after the agent completes
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_GLOSSARY_PATH = './deepfield/drafts/cross-cutting/terminology.md';
+const DEFAULT_WIP_DIR = './deepfield/wip';
+
+/**
+ * Parse CLI arguments into an options object.
+ * @param {string[]} argv - process.argv.slice(2)
+ * @returns {{ run: number, filesJson: string, output: string|null, glossary: string }}
+ */
+function parseArgs(argv) {
+  const opts = {
+    run: null,
+    filesJson: null,
+    output: null,
+    glossary: DEFAULT_GLOSSARY_PATH,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    switch (argv[i]) {
+      case '--run':
+        opts.run = parseInt(argv[++i], 10);
+        break;
+      case '--files-json':
+        opts.filesJson = argv[++i];
+        break;
+      case '--output':
+        opts.output = argv[++i];
+        break;
+      case '--glossary':
+        opts.glossary = argv[++i];
+        break;
+      default:
+        // ignore unknown flags
+    }
+  }
+
+  return opts;
+}
+
+/**
+ * Validate that required options are present.
+ * @param {{ run: number|null, filesJson: string|null }} opts
+ * @throws {Error} if any required option is missing or invalid
+ */
+function validateOpts(opts) {
+  if (opts.run === null || isNaN(opts.run)) {
+    throw new Error('--run <N> is required and must be a number');
+  }
+  if (!opts.filesJson) {
+    throw new Error('--files-json <path> is required');
+  }
+}
+
+/**
+ * Read the file list JSON. Supports two formats:
+ *   - Array of strings: ["path/to/file.js", ...]
+ *   - Object with a "files" key: { "files": ["path/to/file.js", ...] }
+ *
+ * @param {string} filesJsonPath
+ * @returns {string[]} array of file paths
+ */
+function readFileList(filesJsonPath) {
+  const raw = fs.readFileSync(path.resolve(filesJsonPath), 'utf-8');
+  const parsed = JSON.parse(raw);
+
+  if (Array.isArray(parsed)) {
+    return parsed;
+  }
+  if (parsed && Array.isArray(parsed.files)) {
+    return parsed.files;
+  }
+
+  throw new Error(
+    `files-json must be an array of paths or an object with a "files" array. Got: ${typeof parsed}`
+  );
+}
+
+/**
+ * Check whether the glossary file exists.
+ * @param {string} glossaryPath
+ * @returns {boolean}
+ */
+function glossaryExists(glossaryPath) {
+  return fs.existsSync(path.resolve(glossaryPath));
+}
+
+/**
+ * Write the agent input manifest atomically.
+ * @param {string} manifestPath
+ * @param {object} manifest
+ */
+function writeManifest(manifestPath, manifest) {
+  const resolved = path.resolve(manifestPath);
+  const dir = path.dirname(resolved);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  const tmp = resolved + '.tmp';
+  fs.writeFileSync(tmp, JSON.stringify(manifest, null, 2), 'utf-8');
+  fs.renameSync(tmp, resolved);
+}
+
+/**
+ * Write an empty placeholder new-terms.md so the agent has a target path to overwrite.
+ * If the file already exists (e.g., from a retry), it is left as-is so partial
+ * agent results are not discarded.
+ * @param {string} newTermsPath
+ * @param {number} runNumber
+ */
+function writePlaceholder(newTermsPath, runNumber) {
+  const resolved = path.resolve(newTermsPath);
+  if (fs.existsSync(resolved)) {
+    // Already exists — agent may have partially written; don't overwrite.
+    return;
+  }
+  const dir = path.dirname(resolved);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  const content = [
+    `# New Terms — Run ${runNumber}`,
+    '',
+    '> Terms discovered during this run. Merged into `drafts/cross-cutting/terminology.md` automatically.',
+    '',
+    `**Run:** ${runNumber}`,
+    '**Discovered:** 0 terms',
+    '',
+    'Extraction in progress...',
+    '',
+  ].join('\n');
+
+  const tmp = resolved + '.tmp';
+  fs.writeFileSync(tmp, content, 'utf-8');
+  fs.renameSync(tmp, resolved);
+}
+
+/**
+ * Main entry point.
+ * @param {string[]} argv
+ * @returns {{ manifestPath: string, newTermsPath: string, fileCount: number }}
+ */
+function extractTerminology(argv) {
+  const opts = parseArgs(argv);
+  validateOpts(opts);
+
+  const { run, filesJson, glossary } = opts;
+  const wipDir = path.resolve(DEFAULT_WIP_DIR, `run-${run}`);
+
+  // Determine output path for new-terms.md
+  const newTermsPath = opts.output
+    ? path.resolve(opts.output)
+    : path.join(wipDir, 'new-terms.md');
+
+  // Read file list
+  const files = readFileList(filesJson);
+
+  // Check for existing glossary
+  const hasGlossary = glossaryExists(glossary);
+  const glossaryAbsPath = hasGlossary ? path.resolve(glossary) : null;
+
+  // Build agent input manifest
+  const manifest = {
+    runNumber: run,
+    filesToScan: files,
+    previousGlossaryPath: glossaryAbsPath,
+    outputPath: newTermsPath,
+    agentName: 'deepfield-term-extractor',
+    instructions: [
+      `Extract domain-specific terms from ${files.length} file(s) analyzed during Run ${run}.`,
+      hasGlossary
+        ? `Existing glossary is at: ${glossaryAbsPath} — skip terms already defined there.`
+        : 'No existing glossary yet — extract all domain terms found.',
+      `Write results to: ${newTermsPath}`,
+    ].join('\n'),
+  };
+
+  // Write agent input manifest
+  const manifestPath = path.join(wipDir, 'term-extraction-input.json');
+  writeManifest(manifestPath, manifest);
+
+  // Write placeholder (agent will overwrite)
+  writePlaceholder(newTermsPath, run);
+
+  return { manifestPath, newTermsPath, fileCount: files.length };
+}
+
+// CLI entry point
+if (require.main === module) {
+  try {
+    const argv = process.argv.slice(2);
+    if (argv.length === 0 || argv.includes('--help')) {
+      console.log(
+        'Usage: extract-terminology.js --run <N> --files-json <path> [--output <path>] [--glossary <path>]'
+      );
+      process.exit(0);
+    }
+
+    const result = extractTerminology(argv);
+    console.log(`Agent input manifest: ${result.manifestPath}`);
+    console.log(`New-terms placeholder: ${result.newTermsPath}`);
+    console.log(`Files to scan: ${result.fileCount}`);
+    console.log('Ready for deepfield-term-extractor agent.');
+    process.exit(0);
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+module.exports = { extractTerminology, parseArgs, validateOpts, readFileList, glossaryExists };

--- a/plugin/scripts/merge-glossary.js
+++ b/plugin/scripts/merge-glossary.js
@@ -1,0 +1,533 @@
+#!/usr/bin/env node
+/**
+ * merge-glossary.js - Merge per-run new-terms.md into the cumulative terminology.md
+ *
+ * Usage: node merge-glossary.js --run <N> --new-terms <path> [--glossary <path>] [--template <path>]
+ *
+ * Reads new-terms.md (produced by the term-extractor agent) and the existing
+ * terminology.md, merges entries, and writes the updated glossary atomically.
+ *
+ * Merge rules:
+ *   - New term (not in glossary): append to the correct alphabetical section
+ *   - Existing term (case-insensitive match): add new files to its Files list,
+ *     update "Last updated" to the current run
+ *   - Terms are keyed by their canonical name (the ## header in new-terms.md)
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const DEFAULT_GLOSSARY_PATH = './deepfield/drafts/cross-cutting/terminology.md';
+const DEFAULT_TEMPLATE_PATH = path.join(__dirname, '..', 'templates', 'terminology.md');
+
+// ─── Argument Parsing ────────────────────────────────────────────────────────
+
+/**
+ * @param {string[]} argv - process.argv.slice(2)
+ * @returns {{ run: number, newTerms: string, glossary: string, template: string }}
+ */
+function parseArgs(argv) {
+  const opts = {
+    run: null,
+    newTerms: null,
+    glossary: DEFAULT_GLOSSARY_PATH,
+    template: DEFAULT_TEMPLATE_PATH,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    switch (argv[i]) {
+      case '--run':
+        opts.run = parseInt(argv[++i], 10);
+        break;
+      case '--new-terms':
+        opts.newTerms = argv[++i];
+        break;
+      case '--glossary':
+        opts.glossary = argv[++i];
+        break;
+      case '--template':
+        opts.template = argv[++i];
+        break;
+      default:
+        // ignore unknown flags
+    }
+  }
+
+  return opts;
+}
+
+function validateOpts(opts) {
+  if (opts.run === null || isNaN(opts.run)) {
+    throw new Error('--run <N> is required and must be a number');
+  }
+  if (!opts.newTerms) {
+    throw new Error('--new-terms <path> is required');
+  }
+}
+
+// ─── Parsing new-terms.md ────────────────────────────────────────────────────
+
+/**
+ * Parse a new-terms.md file into an array of term objects.
+ *
+ * Expected format per entry:
+ *   ## TERM_NAME
+ *   - **Expansion:** ...
+ *   - **Definition:** ...
+ *   - **Domain:** ...
+ *   - **Files:**
+ *     - `path/to/file.js`
+ *   - **Related:** ...
+ *   - **First seen:** Run N
+ *
+ * @param {string} content - raw file content
+ * @param {number} runNumber - current run number (used as default for firstSeen)
+ * @returns {Term[]}
+ *
+ * @typedef {{ name: string, expansion: string|null, definition: string, domain: string, files: string[], related: string[], firstSeen: string, lastUpdated: string }} Term
+ */
+function parseNewTerms(content, runNumber) {
+  const terms = [];
+  // Split on lines that start with "## " (term header)
+  const sections = content.split(/^## /m).slice(1); // first element before any ## is preamble
+
+  for (const section of sections) {
+    const lines = section.split('\n');
+    const nameLine = lines[0].trim();
+    if (!nameLine || nameLine.startsWith('#')) continue;
+
+    const term = {
+      name: nameLine,
+      expansion: null,
+      definition: '',
+      domain: 'general',
+      files: [],
+      related: [],
+      firstSeen: `Run ${runNumber}`,
+      lastUpdated: `Run ${runNumber}`,
+    };
+
+    let inFiles = false;
+
+    for (let i = 1; i < lines.length; i++) {
+      const line = lines[i];
+
+      // Detect "- **Files:**" block
+      if (/^\s*-\s*\*\*Files:\*\*/.test(line)) {
+        inFiles = true;
+        continue;
+      }
+
+      if (inFiles) {
+        // Indented file entries under Files:
+        const fileMatch = line.match(/^\s+- `?([^`\s]+)`?/);
+        if (fileMatch) {
+          term.files.push(fileMatch[1]);
+          continue;
+        } else if (/^\s*-\s*\*\*/.test(line)) {
+          // Next field starts — exit files block
+          inFiles = false;
+        } else {
+          continue; // blank line or other continuation inside files block
+        }
+      }
+
+      const expansionMatch = line.match(/^\s*-\s*\*\*Expansion:\*\*\s*(.+)/);
+      const definitionMatch = line.match(/^\s*-\s*\*\*Definition:\*\*\s*(.+)/);
+      const domainMatch = line.match(/^\s*-\s*\*\*Domain:\*\*\s*(.+)/);
+      const relatedMatch = line.match(/^\s*-\s*\*\*Related:\*\*\s*(.+)/);
+      const firstSeenMatch = line.match(/^\s*-\s*\*\*First seen:\*\*\s*(.+)/);
+
+      if (expansionMatch) term.expansion = expansionMatch[1].trim();
+      if (definitionMatch) term.definition = definitionMatch[1].trim();
+      if (domainMatch) term.domain = domainMatch[1].trim();
+      if (relatedMatch) {
+        term.related = relatedMatch[1]
+          .split(',')
+          .map(r => r.trim())
+          .filter(Boolean);
+      }
+      if (firstSeenMatch) term.firstSeen = firstSeenMatch[1].trim();
+    }
+
+    // Only include terms with a definition
+    if (term.name && term.definition) {
+      terms.push(term);
+    }
+  }
+
+  return terms;
+}
+
+// ─── Parsing existing terminology.md ─────────────────────────────────────────
+
+/**
+ * Parse the existing terminology.md to extract a map of existing term names
+ * (lowercase) → their line ranges, for update detection.
+ *
+ * We use a simple approach: extract all ### headers within letter sections.
+ *
+ * @param {string} content
+ * @returns {Map<string, { originalName: string, files: string[] }>}
+ */
+function parseExistingGlossary(content) {
+  const existing = new Map();
+
+  // Match entries: ### TERM [EXPANSION]
+  const entryRegex = /^### (.+?)(?:\n|$)/gm;
+  let match;
+
+  while ((match = entryRegex.exec(content)) !== null) {
+    const header = match[1].trim();
+    // Strip expansion in brackets: "SKU [Stock Keeping Unit]" → "SKU"
+    const name = header.replace(/\s*\[.*?\]$/, '').trim();
+
+    // Extract files listed under this entry
+    const entryStart = match.index;
+    const nextEntry = content.indexOf('\n### ', entryStart + 1);
+    const entryBlock = nextEntry === -1
+      ? content.slice(entryStart)
+      : content.slice(entryStart, nextEntry);
+
+    const files = [];
+    const fileRegex = /\*\*Files:\*\*.*?\n((?:\s*- `[^`]+`\n?)+)/s;
+    const fileMatch = entryBlock.match(fileRegex);
+    if (fileMatch) {
+      const fileLines = fileMatch[1].matchAll(/`([^`]+)`/g);
+      for (const fl of fileLines) {
+        files.push(fl[1]);
+      }
+    }
+
+    existing.set(name.toLowerCase(), { originalName: name, files });
+  }
+
+  return existing;
+}
+
+// ─── Rendering ───────────────────────────────────────────────────────────────
+
+/**
+ * Render a single term entry as Markdown.
+ * @param {Term} term
+ * @returns {string}
+ */
+function renderTermEntry(term) {
+  const header = term.expansion
+    ? `### ${term.name} [${term.expansion}]`
+    : `### ${term.name}`;
+
+  const lines = [header, ''];
+  lines.push(`**Definition:** ${term.definition}`);
+  lines.push(`**Domain:** ${term.domain}`);
+
+  if (term.files.length > 0) {
+    lines.push('**Files:**');
+    for (const f of term.files) {
+      lines.push(`- \`${f}\``);
+    }
+  }
+
+  if (term.related.length > 0) {
+    lines.push(`**Related:** ${term.related.join(', ')}`);
+  }
+
+  lines.push(`**First seen:** ${term.firstSeen}`);
+  lines.push(`**Last updated:** ${term.lastUpdated}`);
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+/**
+ * Update a term's entry in the glossary content string:
+ * - Adds new files to its Files list
+ * - Updates "Last updated" field
+ *
+ * @param {string} content - current glossary content
+ * @param {string} termName - canonical name (case-insensitive matched)
+ * @param {string[]} newFiles - new file paths to add
+ * @param {string} runLabel - e.g., "Run 3"
+ * @returns {string} updated content
+ */
+function updateExistingTerm(content, termName, newFiles, runLabel) {
+  // Find the entry block for this term
+  const headerRegex = new RegExp(
+    `(^### ${escapeRegex(termName)}(?:\\s*\\[.*?\\])?)`,
+    'mi'
+  );
+  const headerMatch = headerRegex.exec(content);
+  if (!headerMatch) return content; // not found — shouldn't happen
+
+  const entryStart = headerMatch.index;
+  const nextEntryIdx = content.indexOf('\n### ', entryStart + 1);
+  const beforeEntry = content.slice(0, entryStart);
+  const entryBlock = nextEntryIdx === -1
+    ? content.slice(entryStart)
+    : content.slice(entryStart, nextEntryIdx);
+  const afterEntry = nextEntryIdx === -1 ? '' : content.slice(nextEntryIdx);
+
+  let updated = entryBlock;
+
+  // Add new files that aren't already listed
+  for (const f of newFiles) {
+    const escaped = escapeRegex(f);
+    if (!new RegExp(`\`${escaped}\``).test(updated)) {
+      // Append after the last existing file entry or after **Files:**
+      if (/\*\*Files:\*\*/.test(updated)) {
+        // Find the last file line and insert after it
+        updated = updated.replace(
+          /(\*\*Files:\*\*\n(?:- `[^`]+`\n)*)/,
+          `$1- \`${f}\`\n`
+        );
+      } else {
+        // No files section — add one before the first line that starts "**Related" or "**First"
+        updated = updated.replace(
+          /(\*\*(?:Related|First seen):\*\*)/,
+          `**Files:**\n- \`${f}\`\n$1`
+        );
+      }
+    }
+  }
+
+  // Update "Last updated" field
+  if (/\*\*Last updated:\*\*/.test(updated)) {
+    updated = updated.replace(/\*\*Last updated:\*\*.*/, `**Last updated:** ${runLabel}`);
+  } else {
+    // Append it before the next entry gap
+    updated = updated.trimEnd() + `\n**Last updated:** ${runLabel}\n`;
+  }
+
+  return beforeEntry + updated + afterEntry;
+}
+
+function escapeRegex(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Build the section letter key for a term name.
+ * @param {string} name
+ * @returns {string} single uppercase letter or '#' for non-alpha
+ */
+function sectionLetter(name) {
+  const first = name.trim()[0];
+  if (!first) return '#';
+  const upper = first.toUpperCase();
+  return /[A-Z]/.test(upper) ? upper : '#';
+}
+
+/**
+ * Insert a new term entry into the correct alphabetical section of the glossary.
+ *
+ * @param {string} content - current glossary content
+ * @param {Term} term
+ * @returns {string} updated content
+ */
+function insertNewTerm(content, term) {
+  const letter = sectionLetter(term.name);
+  const sectionHeader = `## ${letter}`;
+  const sectionIdx = content.indexOf(`\n${sectionHeader}\n`);
+
+  const rendered = renderTermEntry(term);
+
+  if (sectionIdx === -1) {
+    // Section doesn't exist — append before the Statistics section or at end
+    const statsIdx = content.indexOf('\n## Statistics\n');
+    if (statsIdx !== -1) {
+      return (
+        content.slice(0, statsIdx) +
+        `\n${sectionHeader}\n\n${rendered}` +
+        content.slice(statsIdx)
+      );
+    }
+    return content + `\n${sectionHeader}\n\n${rendered}`;
+  }
+
+  // Find the end of this section (next ## heading or end of string)
+  const afterSection = sectionIdx + sectionHeader.length + 2; // past "\n## X\n"
+  const nextSectionIdx = content.indexOf('\n## ', afterSection);
+
+  const before = nextSectionIdx === -1
+    ? content.slice(0, content.length)
+    : content.slice(0, nextSectionIdx);
+  const after = nextSectionIdx === -1 ? '' : content.slice(nextSectionIdx);
+
+  // Insert at end of this section (trim trailing whitespace from before)
+  return before.trimEnd() + '\n\n' + rendered.trimEnd() + '\n' + after;
+}
+
+// ─── Statistics Update ────────────────────────────────────────────────────────
+
+/**
+ * Update the statistics block in the glossary.
+ * Counts all ### entries and updates the header metadata.
+ *
+ * @param {string} content
+ * @param {number} runNumber
+ * @returns {string}
+ */
+function updateStatistics(content, runNumber) {
+  // Count total terms
+  const termCount = (content.match(/^### /gm) || []).length;
+
+  // Count domains
+  const domainMatches = content.matchAll(/^\*\*Domain:\*\* (.+)$/gm);
+  const domains = new Set();
+  for (const m of domainMatches) {
+    domains.add(m[1].trim());
+  }
+
+  // Count acronyms (entries with expansion in brackets)
+  const acronymCount = (content.match(/^### .+\[.+\]/gm) || []).length;
+  const businessTermCount = termCount - acronymCount;
+
+  // Update header
+  let updated = content.replace(
+    /\*\*Last updated:\*\* Run \d+/,
+    `**Last updated:** Run ${runNumber}`
+  );
+  updated = updated.replace(
+    /\*\*Total terms:\*\* \d+/,
+    `**Total terms:** ${termCount}`
+  );
+  updated = updated.replace(
+    /\*\*Coverage:\*\* \d+ domains/,
+    `**Coverage:** ${domains.size} domains`
+  );
+
+  // Update statistics section counts
+  updated = updated.replace(
+    /- Acronyms: \d+/,
+    `- Acronyms: ${acronymCount}`
+  );
+  updated = updated.replace(
+    /- Business terms: \d+/,
+    `- Business terms: ${businessTermCount}`
+  );
+
+  return updated;
+}
+
+// ─── Main Merge Logic ─────────────────────────────────────────────────────────
+
+/**
+ * Perform the merge operation.
+ *
+ * @param {{ run: number, newTerms: string, glossary: string, template: string }} opts
+ * @returns {{ added: number, updated: number, glossaryPath: string }}
+ */
+function mergeGlossary(opts) {
+  validateOpts(opts);
+
+  const { run } = opts;
+  const newTermsPath = path.resolve(opts.newTerms);
+  const glossaryPath = path.resolve(opts.glossary);
+  const templatePath = path.resolve(opts.template);
+
+  // Read new-terms.md
+  if (!fs.existsSync(newTermsPath)) {
+    throw new Error(`new-terms file not found: ${newTermsPath}`);
+  }
+  const newTermsContent = fs.readFileSync(newTermsPath, 'utf-8');
+  const newTerms = parseNewTerms(newTermsContent, run);
+
+  // Read or initialize glossary
+  let glossaryContent;
+  if (fs.existsSync(glossaryPath)) {
+    glossaryContent = fs.readFileSync(glossaryPath, 'utf-8');
+  } else {
+    // Bootstrap from template
+    if (!fs.existsSync(templatePath)) {
+      throw new Error(`Glossary not found and template not found: ${templatePath}`);
+    }
+    glossaryContent = fs.readFileSync(templatePath, 'utf-8');
+    // Ensure output directory exists
+    const dir = path.dirname(glossaryPath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+  }
+
+  // Parse existing terms
+  const existingTerms = parseExistingGlossary(glossaryContent);
+
+  let added = 0;
+  let updated = 0;
+  const runLabel = `Run ${run}`;
+
+  for (const term of newTerms) {
+    const key = term.name.toLowerCase();
+
+    if (existingTerms.has(key)) {
+      // Update existing term
+      const existing = existingTerms.get(key);
+      const newFiles = term.files.filter(f => !existing.files.includes(f));
+      if (newFiles.length > 0 || true) {
+        // Always update lastUpdated even with no new files
+        glossaryContent = updateExistingTerm(
+          glossaryContent,
+          existing.originalName,
+          newFiles,
+          runLabel
+        );
+        updated++;
+      }
+    } else {
+      // Insert new term
+      term.lastUpdated = runLabel;
+      glossaryContent = insertNewTerm(glossaryContent, term);
+      existingTerms.set(key, { originalName: term.name, files: term.files });
+      added++;
+    }
+  }
+
+  // Update statistics and header
+  glossaryContent = updateStatistics(glossaryContent, run);
+
+  // Write atomically
+  const tmpPath = glossaryPath + '.tmp';
+  fs.writeFileSync(tmpPath, glossaryContent, 'utf-8');
+  fs.renameSync(tmpPath, glossaryPath);
+
+  return { added, updated, glossaryPath };
+}
+
+// ─── CLI Entry Point ──────────────────────────────────────────────────────────
+
+if (require.main === module) {
+  const argv = process.argv.slice(2);
+
+  if (argv.length === 0 || argv.includes('--help')) {
+    console.log(
+      'Usage: merge-glossary.js --run <N> --new-terms <path> [--glossary <path>] [--template <path>]'
+    );
+    process.exit(0);
+  }
+
+  try {
+    const opts = parseArgs(argv);
+    const result = mergeGlossary(opts);
+    console.log(`Glossary updated: ${result.glossaryPath}`);
+    console.log(`  Added:   ${result.added} new terms`);
+    console.log(`  Updated: ${result.updated} existing terms`);
+    process.exit(0);
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  mergeGlossary,
+  parseArgs,
+  validateOpts,
+  parseNewTerms,
+  parseExistingGlossary,
+  renderTermEntry,
+  insertNewTerm,
+  updateExistingTerm,
+  updateStatistics,
+};

--- a/plugin/skills/deepfield-bootstrap.md
+++ b/plugin/skills/deepfield-bootstrap.md
@@ -70,6 +70,23 @@ The script handles all bootstrap steps automatically:
 9. Creates `deepfield/source/run-1-staging/` with README and feedback template
 10. Updates `deepfield/project.config.json` (bootstrapCompleted: true)
 
+## Step 2.5: Initialize Terminology Glossary
+
+After the bootstrap runner script completes, create the empty terminology glossary:
+
+```bash
+# Create the cross-cutting drafts directory if it doesn't exist
+mkdir -p deepfield/drafts/cross-cutting
+
+# Copy the terminology template to initialize the empty glossary
+cp "${CLAUDE_PLUGIN_ROOT}/templates/terminology.md" \
+   deepfield/drafts/cross-cutting/terminology.md
+```
+
+This establishes the glossary file so that Run 1 can immediately start appending discovered terms without needing to create the file from scratch.
+
+If the glossary already exists (e.g., re-running bootstrap), skip this step to preserve any previously discovered terms.
+
 ## Step 3: Verify Output
 
 After the script completes, verify these files exist:
@@ -81,6 +98,7 @@ After the script completes, verify these files exist:
 - `deepfield/wip/run-0/findings.md` — Bootstrap findings summary
 - `deepfield/source/run-1-staging/README.md` — Staging area guide
 - `deepfield/source/run-1-staging/feedback.md` — Open questions template
+- `deepfield/drafts/cross-cutting/terminology.md` — Empty terminology glossary (initialized from template)
 
 ## Step 4: Report Completion
 
@@ -166,6 +184,7 @@ Bootstrap is successful when:
 - `deepfield/wip/domain-index.md` exists
 - `deepfield/wip/learning-plan.md` exists
 - `deepfield/project.config.json` has `bootstrapCompleted: true`
+- `deepfield/drafts/cross-cutting/terminology.md` exists (initialized from template)
 
 # State Transition
 

--- a/plugin/skills/deepfield-iterate.md
+++ b/plugin/skills/deepfield-iterate.md
@@ -218,6 +218,69 @@ Synthesizer updates:
 - `deepfield/drafts/cross-cutting/unknowns.md` - Add/remove unknowns
 - `deepfield/drafts/_changelog.md` - Append run summary
 
+## Step 5.5: Extract Terminology
+
+After synthesis, extract domain-specific terms from the files analyzed this run and merge them into the cumulative glossary.
+
+### Prepare File List
+
+Write the list of files analyzed this run to a temporary JSON file:
+
+```bash
+# filesToRead was built in Step 3 (Incremental Scanning)
+node -e "
+const fs = require('fs');
+fs.writeFileSync(
+  'deepfield/wip/run-${nextRun}/files-analyzed.json',
+  JSON.stringify({ files: filesToRead })
+);
+"
+```
+
+### Run Term Extraction Script
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/extract-terminology.js" \
+  --run ${nextRun} \
+  --files-json deepfield/wip/run-${nextRun}/files-analyzed.json \
+  --glossary deepfield/drafts/cross-cutting/terminology.md
+```
+
+This writes `deepfield/wip/run-${nextRun}/term-extraction-input.json` and a placeholder `deepfield/wip/run-${nextRun}/new-terms.md`.
+
+### Invoke Term Extractor Agent
+
+```
+Launch: deepfield-term-extractor
+Input: {
+  "run_number": ${nextRun},
+  "manifest": "deepfield/wip/run-${nextRun}/term-extraction-input.json",
+  "files_to_scan": <filesToRead>,
+  "previous_glossary": "deepfield/drafts/cross-cutting/terminology.md",
+  "output_path": "deepfield/wip/run-${nextRun}/new-terms.md"
+}
+```
+
+The agent reads source files and writes discovered terms to `deepfield/wip/run-${nextRun}/new-terms.md`.
+
+### Merge Into Cumulative Glossary
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/merge-glossary.js" \
+  --run ${nextRun} \
+  --new-terms deepfield/wip/run-${nextRun}/new-terms.md \
+  --glossary deepfield/drafts/cross-cutting/terminology.md \
+  --template "${CLAUDE_PLUGIN_ROOT}/templates/terminology.md"
+```
+
+This merges per-run discoveries into `deepfield/drafts/cross-cutting/terminology.md`.
+
+### Error Handling
+
+If extraction or merge fails:
+- Log a warning: `Warning: Terminology extraction failed for Run ${nextRun}: <error>`
+- Continue to Step 6 — terminology extraction is non-blocking
+
 ## Step 6: Update Learning Plan
 
 ### Calculate Confidence Changes

--- a/plugin/templates/new-terms.md
+++ b/plugin/templates/new-terms.md
@@ -1,0 +1,25 @@
+# New Terms — Run N
+
+> Terms discovered during this run. Merged into `drafts/cross-cutting/terminology.md` automatically.
+
+**Run:** N
+**Discovered:** 0 terms
+
+---
+
+<!--
+Each entry uses this format:
+
+## TERM
+
+- **Expansion:** (acronym expansion, if applicable — omit if not an acronym)
+- **Definition:** One or two sentence definition of what this term means.
+- **Domain:** domain-name (e.g., catalog, fulfillment, payments)
+- **Files:**
+  - `path/to/file.js`
+  - `path/to/docs.md`
+- **Related:** other-term, another-term (omit if none)
+- **First seen:** Run N
+
+---
+-->

--- a/plugin/templates/terminology.md
+++ b/plugin/templates/terminology.md
@@ -1,0 +1,149 @@
+# Terminology Index
+
+> Living glossary of domain-specific terms, acronyms, and definitions.
+> Automatically maintained by Deepfield — updated each run.
+
+**Last updated:** Run 0
+**Total terms:** 0
+**Coverage:** 0 domains
+
+---
+
+## Index
+
+[A](#a) [B](#b) [C](#c) [D](#d) [E](#e) [F](#f) [G](#g) [H](#h) [I](#i)
+[J](#j) [K](#k) [L](#l) [M](#m) [N](#n) [O](#o) [P](#p) [Q](#q) [R](#r)
+[S](#s) [T](#t) [U](#u) [V](#v) [W](#w) [X](#x) [Y](#y) [Z](#z)
+
+---
+
+## A
+
+<!-- Terms starting with A -->
+
+## B
+
+<!-- Terms starting with B -->
+
+## C
+
+<!-- Terms starting with C -->
+
+## D
+
+<!-- Terms starting with D -->
+
+## E
+
+<!-- Terms starting with E -->
+
+## F
+
+<!-- Terms starting with F -->
+
+## G
+
+<!-- Terms starting with G -->
+
+## H
+
+<!-- Terms starting with H -->
+
+## I
+
+<!-- Terms starting with I -->
+
+## J
+
+<!-- Terms starting with J -->
+
+## K
+
+<!-- Terms starting with K -->
+
+## L
+
+<!-- Terms starting with L -->
+
+## M
+
+<!-- Terms starting with M -->
+
+## N
+
+<!-- Terms starting with N -->
+
+## O
+
+<!-- Terms starting with O -->
+
+## P
+
+<!-- Terms starting with P -->
+
+## Q
+
+<!-- Terms starting with Q -->
+
+## R
+
+<!-- Terms starting with R -->
+
+## S
+
+<!-- Terms starting with S -->
+
+## T
+
+<!-- Terms starting with T -->
+
+## U
+
+<!-- Terms starting with U -->
+
+## V
+
+<!-- Terms starting with V -->
+
+## W
+
+<!-- Terms starting with W -->
+
+## X
+
+<!-- Terms starting with X -->
+
+## Y
+
+<!-- Terms starting with Y -->
+
+## Z
+
+<!-- Terms starting with Z -->
+
+---
+
+## Statistics
+
+**By domain:** *(none yet)*
+
+**By type:**
+- Acronyms: 0
+- Business terms: 0
+- Technical terms: 0
+
+---
+
+*This glossary is maintained automatically. Each entry shows: definition, domain, source files, and when the term was first discovered.*
+
+<!--
+ENTRY FORMAT (used by merge-glossary.js — do not remove this comment):
+
+### TERM [EXPANSION]
+**Definition:** Description of the term.
+**Domain:** domain-name
+**Files:** `path/to/file.js`
+**Related:** other-term, another-term
+**First seen:** Run N
+**Last updated:** Run N
+-->


### PR DESCRIPTION
## Summary

- Adds a living `drafts/cross-cutting/terminology.md` glossary that grows cumulatively across learning runs
- Introduces a new `deepfield-term-extractor` agent that reads analyzed source files and extracts domain-specific terms, acronyms, and definitions
- Two new scripts: `extract-terminology.js` (orchestrates extraction, writes agent input manifest) and `merge-glossary.js` (merges per-run terms into the cumulative glossary atomically using tmp-then-rename)
- Integrates into the iterate skill as non-blocking Step 5.5 (after synthesis, before learning plan update); failures warn and continue
- Bootstrap initializes an empty `terminology.md` from the template during Run 0

Closes #28

## Test plan

- [ ] Run bootstrap (`/df-bootstrap`) — verify `deepfield/drafts/cross-cutting/terminology.md` is created from the template
- [ ] Run iterate (`/df-iterate`) — verify `deepfield/wip/run-N/new-terms.md` is written after the term-extractor agent runs
- [ ] Verify `merge-glossary.js` updates `terminology.md` alphabetically with entries from `new-terms.md`
- [ ] Run iterate a second time — verify existing terms get their `Last updated` bumped; new terms are appended
- [ ] Simulate extraction failure — verify the run continues to Step 6 with a warning rather than aborting
- [ ] Manually test `extract-terminology.js --help` and `merge-glossary.js --help` print usage without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)