### PR TITLE
feat: add /df-ff fast-forward command

### DIFF
--- a/openspec/changes/df-ff-command/.openspec.yaml
+++ b/openspec/changes/df-ff-command/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-04

--- a/openspec/changes/df-ff-command/design.md
+++ b/openspec/changes/df-ff-command/design.md
@@ -1,0 +1,68 @@
+## Context
+
+The Deepfield plugin already has a `deepfield-iterate` skill that runs learning iterations in an autonomous loop with stop condition evaluation. The `/df-iterate` command invokes this skill with optional single-run (`--once`) and focus (`--focus`) flags.
+
+The fast-forward command adds a higher-level loop controller that: (1) suppresses user feedback prompts between runs, (2) enforces a configurable max-runs cap, (3) targets a minimum confidence threshold across selected domains, and (4) reports progress after all runs complete rather than after each one.
+
+The confidence score is the key new concept — it represents the percentage of HIGH-priority topics in the learning plan that have reached their confidence target (>= min-confidence).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Run multiple iterations without user intervention
+- Stop when any stop condition fires: confidence reached, max runs hit, diminishing returns, blocked, domain restructure
+- Report per-run progress and final summary
+- Support domain filtering (`--domains`) and configurable thresholds
+- Optionally collect feedback at end of all runs
+
+**Non-Goals:**
+- Replace or modify the existing `deepfield-iterate` skill behavior
+- Implement a new learning algorithm — reuse iterate skill per run
+- Implement a background/daemon process — runs synchronously in Claude session
+- Parallel iteration across domains simultaneously
+
+## Decisions
+
+### Decision 1: Reuse deepfield-iterate skill per run rather than duplicating logic
+
+**Chosen:** The `deepfield-ff` skill invokes the `deepfield-iterate` skill logic for each individual run, passing `--once` mode to execute exactly one run, then evaluates stop conditions in the outer ff loop.
+
+**Alternative considered:** Copy the iterate skill logic into df-ff. Rejected because this creates duplication and maintenance burden. The iterate skill already handles scanning, learning, synthesis, and run config updates correctly.
+
+**Rationale:** Single responsibility. The ff skill only adds: loop control, confidence threshold evaluation, and suppression of between-run user prompts.
+
+### Decision 2: Confidence scoring reads from run-N.config.json
+
+**Chosen:** `check-confidence.js` reads the most recent run config's `confidenceChanges` field and the learning plan's topic list to compute the percentage of HIGH-priority topics at or above the threshold.
+
+**Alternative considered:** Parse confidence directly from `learning-plan.md` markdown. Rejected because markdown parsing is fragile; the structured JSON in run configs is more reliable.
+
+**Rationale:** run-N.config.json is already written by the iterate skill with per-topic confidence. The script can compute a single aggregate score from this.
+
+### Decision 3: --domains filter limits both topic selection and threshold evaluation
+
+**Chosen:** When `--domains auth,api` is passed, the confidence threshold check only evaluates topics belonging to those domains. Topics outside the filter are ignored for stop condition purposes.
+
+**Alternative considered:** Filter only affects topic selection but threshold still checks all domains. Rejected because users running `--domains auth` don't want to wait for unrelated domains.
+
+**Rationale:** Domain-focused runs should have domain-scoped exit criteria.
+
+### Decision 4: Feedback collection at end is opt-out (default: true)
+
+**Chosen:** After all runs complete, if `--feedback-at-end` is not explicitly `false`, Claude prompts the user to review findings and add feedback before running again.
+
+**Alternative considered:** Default off, require explicit `--feedback-at-end` flag. Rejected because silent completion without any feedback hook removes the human-in-the-loop entirely, which could lead to divergent knowledge bases.
+
+**Rationale:** The feedback prompt is lightweight (just a message with instructions) and preserves the iterative review cycle that makes Deepfield trustworthy.
+
+## Risks / Trade-offs
+
+- **Long-running sessions**: Many runs in a single Claude session may hit context limits. Mitigation: Hard cap `--max-runs` at 50, default 10. Warn user at runs > 20.
+- **Confidence stagnation without detection**: If confidence scores don't update (bug in iterate skill), the ff loop could run to max-runs silently. Mitigation: Diminishing returns check (2+ runs with <5% net change) catches this case.
+- **No graceful Ctrl+C handling in Claude**: Claude Code doesn't expose signal handling. Mitigation: Document that cancellation leaves state in the last completed run; user can resume with `/df-continue`.
+- **Domain filter typos**: If user specifies `--domains auth` but domain is named `authentication`, the filter silently matches nothing. Mitigation: Validate domains against domain-index.md and warn if no topics matched.
+
+## Open Questions
+
+- Should `--stop-on-blocked` default to false (as per issue) or true? Kept as false per issue spec — run continues even if some topics are blocked, unless ALL high-priority topics are blocked.
+- Is 80% min-confidence threshold the right default? Matches the existing stop condition in iterate skill (`confidence > 80`). Kept consistent.

--- a/openspec/changes/df-ff-command/proposal.md
+++ b/openspec/changes/df-ff-command/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Users running `/df-iterate` must manually trigger each learning cycle and wait for feedback prompts between runs, making the process slow and requiring constant attention for projects with clear structure and good sources. A fast-forward command enables autonomous multi-run learning without user intervention, enabling batch and CI/CD use cases.
+
+## What Changes
+
+- Add new `/df-ff` command that runs multiple learning iterations autonomously
+- Add new `deepfield-ff` skill that orchestrates the fast-forward loop with configurable stop conditions
+- Add `check-confidence.js` script that calculates confidence scores from run configs and learning plan
+- Stop conditions: confidence threshold reached, max runs hit, diminishing returns, blocked on sources, domain restructure detected
+- Progress reporting after each run showing confidence changes per topic
+- Feedback collection prompt at end (optional, default on)
+- No user feedback prompts between individual runs
+
+## Capabilities
+
+### New Capabilities
+
+- `df-ff-command`: The `/df-ff` Claude Code plugin command — validates prerequisites, parses arguments (`--max-runs`, `--min-confidence`, `--domains`, `--stop-on-blocked`, `--feedback-at-end`), then invokes the `deepfield-ff` skill
+- `deepfield-ff-skill`: Skill that orchestrates multiple learning iterations in a loop, evaluating stop conditions after each run and reporting progress, without pausing for user feedback between runs
+- `confidence-scoring`: Script (`check-confidence.js`) that reads run configs and learning plan to compute current per-domain confidence scores and determine if thresholds are met
+
+### Modified Capabilities
+
+- `plugin-commands`: New command file added to the command set (no requirement change, just addition)
+
+## Impact
+
+- New files: `plugin/commands/df-ff.md`, `plugin/skills/deepfield-ff.md`, `plugin/scripts/check-confidence.js`
+- Depends on existing `deepfield-iterate` skill logic (invokes it per run or reuses its internals)
+- No breaking changes to existing commands
+- Relies on `run-N.config.json` confidence data written by existing iterate skill

--- a/openspec/changes/df-ff-command/specs/confidence-scoring/spec.md
+++ b/openspec/changes/df-ff-command/specs/confidence-scoring/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: check-confidence.js reads confidence from run config and learning plan
+The `check-confidence.js` script SHALL read the most recent completed run's config JSON and the learning plan markdown to compute confidence scores, and output a JSON result.
+
+Script signature:
+```
+node check-confidence.js <deepfield-dir> [--domains <comma-separated>] [--threshold <number>]
+```
+
+Output JSON:
+```json
+{
+  "overallConfidence": 72,
+  "thresholdMet": false,
+  "threshold": 80,
+  "topics": [
+    { "name": "Authentication", "priority": "HIGH", "confidence": 85, "meetsThreshold": true },
+    { "name": "API Structure", "priority": "HIGH", "confidence": 60, "meetsThreshold": false }
+  ],
+  "highPriorityCount": 2,
+  "highPriorityMeetingThreshold": 1,
+  "domainsFilter": ["auth"]
+}
+```
+
+#### Scenario: Confidence computed from latest run config
+- **WHEN** script is run with a valid deepfield directory containing run configs
+- **THEN** script reads the highest-numbered run-N.config.json, extracts confidenceChanges, and computes per-topic confidence as the "after" value for each topic
+
+#### Scenario: Threshold met
+- **WHEN** all HIGH-priority topics (in domain filter if specified) have confidence >= threshold
+- **THEN** output JSON has `"thresholdMet": true`
+
+#### Scenario: Threshold not met
+- **WHEN** any HIGH-priority topic in scope has confidence < threshold
+- **THEN** output JSON has `"thresholdMet": false`
+
+#### Scenario: Domain filter applied
+- **WHEN** `--domains auth,api` is passed
+- **THEN** `topics` array in output only includes topics whose domain matches one of the filter values; `thresholdMet` only considers those topics
+
+#### Scenario: No run configs found
+- **WHEN** no run-N.config.json files exist (only run-0 or none)
+- **THEN** script outputs `{ "error": "No completed learning runs found. Run /df-iterate or /df-ff first." }` and exits with code 1
+
+#### Scenario: Script failure does not crash
+- **WHEN** deepfield-dir does not exist or is malformed
+- **THEN** script prints error to stderr and exits with non-zero code; calling skill treats this as a non-fatal error and continues with confidence assumed as 0
+
+### Requirement: check-confidence.js uses CJS module format
+The script SHALL use `require` and `module.exports` (CommonJS), consistent with all other scripts in `plugin/scripts/`.
+
+#### Scenario: Script loads without ESM errors
+- **WHEN** script is executed with `node check-confidence.js`
+- **THEN** no "Cannot use import statement" errors occur; script uses `require('fs')`, `require('path')`, etc.

--- a/openspec/changes/df-ff-command/specs/deepfield-ff-skill/spec.md
+++ b/openspec/changes/df-ff-command/specs/deepfield-ff-skill/spec.md
@@ -1,0 +1,101 @@
+## ADDED Requirements
+
+### Requirement: deepfield-ff skill runs multiple iterations without user prompts
+The `deepfield-ff` skill SHALL execute multiple learning iterations by invoking the `deepfield-iterate` skill logic in single-run (`--once`) mode repeatedly, without pausing for user feedback between runs.
+
+#### Scenario: Multiple runs executed sequentially
+- **WHEN** skill starts with max-runs=5 and confidence threshold not yet met
+- **THEN** skill executes Run N, evaluates stop conditions, increments run counter, and executes Run N+1 until a stop condition fires or max-runs is reached
+
+#### Scenario: No feedback prompts between runs
+- **WHEN** a single run completes mid-loop
+- **THEN** skill immediately begins the next run without asking user for input or feedback
+
+### Requirement: deepfield-ff skill evaluates stop conditions after each run
+After each completed run, the skill SHALL evaluate all stop conditions in order and stop if any condition is met.
+
+Stop conditions in evaluation order:
+1. **CONFIDENCE_REACHED**: All HIGH-priority topics (in selected domains) have confidence >= min-confidence
+2. **MAX_RUNS_HIT**: Number of runs executed in this ff session >= max-runs parameter
+3. **DIMINISHING_RETURNS**: Last 2 completed runs each had net confidence change < 5% across all focus topics
+4. **BLOCKED**: All HIGH-priority topics in selected domains have status "blocked" AND `--stop-on-blocked` flag is set
+5. **DOMAIN_RESTRUCTURE**: Domain count changed by more than 3 compared to session start
+
+#### Scenario: Confidence threshold reached
+- **WHEN** after a run, all HIGH-priority topics in scope have confidence >= min-confidence
+- **THEN** skill stops with stop reason CONFIDENCE_REACHED and reports success
+
+#### Scenario: Max runs hit
+- **WHEN** the skill has executed max-runs iterations in this session
+- **THEN** skill stops with stop reason MAX_RUNS_HIT even if confidence threshold not met
+
+#### Scenario: Diminishing returns detected
+- **WHEN** the last 2 consecutive runs each produced < 5% net confidence change across focus topics
+- **THEN** skill stops with stop reason DIMINISHING_RETURNS
+
+#### Scenario: Blocked with stop-on-blocked enabled
+- **WHEN** all HIGH-priority topics are blocked AND --stop-on-blocked was specified
+- **THEN** skill stops with stop reason BLOCKED
+
+#### Scenario: Domain restructure detected
+- **WHEN** domain count at end of a run differs from session-start domain count by more than 3
+- **THEN** skill stops with stop reason DOMAIN_RESTRUCTURE
+
+### Requirement: deepfield-ff skill reports per-run progress
+After each individual run completes, the skill SHALL print a compact progress line showing: run number, topics focused, and confidence changes for those topics.
+
+#### Scenario: Per-run progress line
+- **WHEN** Run N completes within the ff loop
+- **THEN** skill prints: "Run N complete | <topic>: X%→Y% | <topic>: X%→Y% | ..."
+
+### Requirement: deepfield-ff skill prints a final summary report on stop
+When the loop exits for any stop reason, the skill SHALL print a comprehensive final report including: total runs executed, stop reason with explanation, per-topic confidence table (before session → after session), questions answered/raised, and next step suggestions appropriate to the stop reason.
+
+#### Scenario: Final report on confidence reached
+- **WHEN** stop reason is CONFIDENCE_REACHED
+- **THEN** report celebrates completion and suggests `/df-output` or `/df-status`
+
+#### Scenario: Final report on max runs
+- **WHEN** stop reason is MAX_RUNS_HIT
+- **THEN** report shows progress made and prompts user to add feedback to staging area, then run `/df-continue`
+
+#### Scenario: Final report on diminishing returns
+- **WHEN** stop reason is DIMINISHING_RETURNS
+- **THEN** report suggests adding new sources or reviewing unknowns.md
+
+#### Scenario: Final report on blocked
+- **WHEN** stop reason is BLOCKED
+- **THEN** report lists which sources are needed for which blocked topics
+
+#### Scenario: Final report on domain restructure
+- **WHEN** stop reason is DOMAIN_RESTRUCTURE
+- **THEN** report prompts user to review domain-index.md and confirm structure
+
+### Requirement: deepfield-ff skill creates staging area on stop
+After the loop exits (any stop reason), the skill SHALL create the next run's staging area directory with README and feedback template, identical to the staging area created by `deepfield-iterate`.
+
+#### Scenario: Staging area created
+- **WHEN** the ff loop exits after completing Run N
+- **THEN** `deepfield/source/run-{N+1}-staging/` is created with `README.md` and `feedback.md` populated with current open questions
+
+### Requirement: deepfield-ff skill optionally collects feedback at end
+If `--feedback-at-end` is true (the default), after printing the final report and creating the staging area, the skill SHALL prompt the user to review the output and add feedback before the session ends.
+
+#### Scenario: Feedback prompt shown by default
+- **WHEN** ff loop completes and feedback-at-end is true
+- **THEN** skill prints instructions to review `deepfield/drafts/` and add feedback to the staging directory, then run `/df-continue`
+
+#### Scenario: Feedback prompt suppressed
+- **WHEN** `--feedback-at-end false` was passed
+- **THEN** skill completes without any feedback prompt
+
+### Requirement: deepfield-ff skill validates domain filter against known domains
+If `--domains` filter is provided, the skill SHALL validate the specified domain names against the domain index and warn if any specified domain does not match a known domain.
+
+#### Scenario: Unknown domain in filter
+- **WHEN** user specifies `--domains xyz` and "xyz" is not in `deepfield/wip/domain-index.md`
+- **THEN** skill prints a warning "Domain 'xyz' not found in domain index. Known domains: <list>" but continues with other valid domains
+
+#### Scenario: All specified domains unknown
+- **WHEN** all domains in filter are unknown
+- **THEN** skill stops with error "No valid domains found matching filter. Check /df-status for domain list."

--- a/openspec/changes/df-ff-command/specs/df-ff-command/spec.md
+++ b/openspec/changes/df-ff-command/specs/df-ff-command/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: df-ff command validates prerequisites before starting
+The `/df-ff` command SHALL verify the same prerequisites as `/df-iterate` before invoking any skill: `deepfield/` directory exists, Run 0 is complete (`deepfield/wip/run-0/run-0.config.json` exists), and `deepfield/wip/learning-plan.md` exists.
+
+#### Scenario: Missing deepfield directory
+- **WHEN** user runs `/df-ff` and no `deepfield/` directory exists in cwd
+- **THEN** command prints "No deepfield/ directory found. Run /df-init first." and exits without invoking the skill
+
+#### Scenario: Bootstrap not complete
+- **WHEN** user runs `/df-ff` and `deepfield/wip/run-0/run-0.config.json` does not exist
+- **THEN** command prints "Bootstrap (Run 0) not complete. Run /df-continue first." and exits
+
+#### Scenario: No learning plan
+- **WHEN** user runs `/df-ff` and `deepfield/wip/learning-plan.md` does not exist
+- **THEN** command prints "No learning plan found. Bootstrap may have failed. Check /df-status." and exits
+
+#### Scenario: All prerequisites satisfied
+- **WHEN** user runs `/df-ff` and all prerequisites exist
+- **THEN** command prints starting message and invokes the `deepfield-ff` skill
+
+### Requirement: df-ff command accepts configurable arguments
+The `/df-ff` command SHALL accept the following optional arguments and pass them to the `deepfield-ff` skill:
+
+- `--max-runs <n>`: Maximum number of iterations to execute (default: 10, hard cap: 50)
+- `--min-confidence <n>`: Minimum confidence percentage threshold to achieve (default: 80)
+- `--domains <list>`: Comma-separated domain names to focus on (default: all domains)
+- `--stop-on-blocked`: Flag that stops execution if any run is blocked (default: false)
+- `--feedback-at-end`: Flag controlling whether to prompt for feedback after all runs (default: true)
+
+#### Scenario: Default arguments
+- **WHEN** user runs `/df-ff` with no arguments
+- **THEN** skill is invoked with max-runs=10, min-confidence=80, domains=all, stop-on-blocked=false, feedback-at-end=true
+
+#### Scenario: Custom max-runs
+- **WHEN** user runs `/df-ff --max-runs 5`
+- **THEN** skill is invoked with max-runs=5
+
+#### Scenario: Max runs exceeds hard cap
+- **WHEN** user runs `/df-ff --max-runs 100`
+- **THEN** command warns "max-runs capped at 50" and invokes skill with max-runs=50
+
+#### Scenario: Domain filter specified
+- **WHEN** user runs `/df-ff --domains auth,api`
+- **THEN** skill is invoked with domains filter set to ["auth", "api"]
+
+#### Scenario: Unknown argument
+- **WHEN** user runs `/df-ff --unknown-flag`
+- **THEN** command prints usage help and exits with error
+
+### Requirement: df-ff command shows start summary before delegating
+The `/df-ff` command SHALL print a brief start summary showing the configuration before invoking the skill, so the user knows what will run.
+
+#### Scenario: Start summary printed
+- **WHEN** all prerequisites pass and valid arguments are parsed
+- **THEN** command prints: max-runs, min-confidence target, domain filter (or "all"), and then "Invoking fast-forward learning..." before delegating to skill

--- a/openspec/changes/df-ff-command/tasks.md
+++ b/openspec/changes/df-ff-command/tasks.md
@@ -1,0 +1,30 @@
+## 1. Confidence Scoring Script
+
+- [x] 1.1 Create `plugin/scripts/check-confidence.js` using CJS (require/module.exports)
+- [x] 1.2 Implement logic to find the highest-numbered run-N.config.json in `deepfield/wip/`
+- [x] 1.3 Implement confidence extraction from `confidenceChanges` field in run config
+- [x] 1.4 Implement domain filter logic to restrict topic evaluation
+- [x] 1.5 Implement threshold evaluation: compute `thresholdMet` boolean from HIGH-priority topics
+- [x] 1.6 Output JSON result to stdout; write errors to stderr with non-zero exit code
+
+## 2. deepfield-ff Skill
+
+- [x] 2.1 Create `plugin/skills/deepfield-ff.md` with YAML frontmatter (name, description, trigger_mode, user_invocable)
+- [x] 2.2 Document skill input parameters: max-runs, min-confidence, domains, stop-on-blocked, feedback-at-end
+- [x] 2.3 Implement domain filter validation against domain-index.md (warn on unknown domains, error if all unknown)
+- [x] 2.4 Implement the main ff loop: invoke deepfield-iterate in single-run mode, evaluate stop conditions, repeat
+- [x] 2.5 Implement per-run progress line output after each completed run
+- [x] 2.6 Implement all 5 stop condition checks using check-confidence.js output and run config data
+- [x] 2.7 Implement staging area creation on loop exit (delegate to iterate skill pattern or replicate logic)
+- [x] 2.8 Implement final summary report with stop reason, per-topic confidence table, and next-steps section
+- [x] 2.9 Implement feedback-at-end prompt (shown by default, suppressed if feedback-at-end=false)
+
+## 3. df-ff Command
+
+- [x] 3.1 Create `plugin/commands/df-ff.md` with YAML frontmatter (name, description, allowed-tools, arguments)
+- [x] 3.2 Document all arguments: --max-runs, --min-confidence, --domains, --stop-on-blocked, --feedback-at-end
+- [x] 3.3 Implement prerequisite validation (deepfield/ exists, run-0 config exists, learning-plan.md exists)
+- [x] 3.4 Implement argument parsing and validation (hard cap max-runs at 50, warn if exceeded)
+- [x] 3.5 Implement start summary printout (config values before delegating)
+- [x] 3.6 Implement skill invocation: delegate to deepfield-ff skill with parsed arguments
+- [x] 3.7 Add error messages for each validation failure matching the spec scenarios

--- a/plugin/commands/df-ff.md
+++ b/plugin/commands/df-ff.md
@@ -1,0 +1,247 @@
+---
+name: df-ff
+description: Fast-forward autonomous learning — run multiple iterations without user intervention until confidence thresholds are met or limits are reached
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Task
+arguments:
+  - name: --max-runs
+    description: Maximum number of iterations to execute in this session (default: 10, hard cap: 50)
+    required: false
+  - name: --min-confidence
+    description: Minimum confidence percentage for HIGH-priority topics to achieve before stopping (default: 80)
+    required: false
+  - name: --domains
+    description: Comma-separated domain names to focus on, e.g. --domains auth,api (default: all domains)
+    required: false
+  - name: --stop-on-blocked
+    description: Stop if all high-priority topics in scope are blocked waiting for sources (default: false)
+    required: false
+  - name: --feedback-at-end
+    description: Prompt for feedback review after all runs complete (default: true). Pass --feedback-at-end false to suppress.
+    required: false
+---
+
+# /df-ff - Fast-Forward Autonomous Learning
+
+Run multiple learning iterations autonomously without stopping for user feedback between runs. Continues until confidence thresholds are met, max runs are hit, or other stop conditions fire.
+
+## Use Cases
+
+- **Well-documented projects**: Run until high confidence is achieved without manual intervention
+- **Batch learning**: Fire-and-forget during lunch or overnight, review results once
+- **CI/CD**: Automated knowledge base updates when code changes
+
+## Comparison with /df-iterate
+
+| Command | Runs | User Feedback | Stop Condition |
+|---------|------|---------------|----------------|
+| `/df-iterate` | 1 | After each run | Manual |
+| `/df-ff` | Multiple | At end only | Confidence / auto |
+
+## Usage Examples
+
+```bash
+# Run up to 10 iterations (default), stop when 80% confidence reached
+/df-ff
+
+# Run up to 5 iterations, stop when 85% confidence reached
+/df-ff --max-runs 5 --min-confidence 85
+
+# Focus only on auth and api domains
+/df-ff --domains auth,api
+
+# Stop immediately if blocked, no feedback prompt at end
+/df-ff --stop-on-blocked --feedback-at-end false
+
+# Long batch run with custom threshold
+/df-ff --max-runs 20 --min-confidence 90
+```
+
+## Prerequisites
+
+Before running, verify ALL of the following:
+
+1. **deepfield/ directory exists** in the current working directory
+2. **Bootstrap (Run 0) is complete**: `deepfield/wip/run-0/run-0.config.json` exists
+3. **Learning plan exists**: `deepfield/wip/learning-plan.md`
+
+If any prerequisite fails, display a clear error and suggest the correct command.
+
+## Implementation
+
+### Step 1: Validate Prerequisites
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check deepfield directory
+if [ ! -d "./deepfield" ]; then
+  echo "No deepfield/ directory found. Run /df-init first."
+  exit 1
+fi
+
+# Check Run 0 completed
+if [ ! -f "./deepfield/wip/run-0/run-0.config.json" ]; then
+  echo "Bootstrap (Run 0) not complete. Run /df-continue first."
+  exit 1
+fi
+
+# Check learning plan
+if [ ! -f "./deepfield/wip/learning-plan.md" ]; then
+  echo "No learning plan found. Bootstrap may have failed. Check /df-status."
+  exit 1
+fi
+```
+
+### Step 2: Parse Arguments
+
+Parse the following arguments with defaults:
+
+```bash
+MAX_RUNS=10
+MIN_CONFIDENCE=80
+DOMAINS=""
+STOP_ON_BLOCKED=false
+FEEDBACK_AT_END=true
+
+for arg in "$@"; do
+  case $arg in
+    --max-runs=*)
+      MAX_RUNS="${arg#*=}"
+      ;;
+    --max-runs)
+      # handled as next argument
+      ;;
+    --min-confidence=*)
+      MIN_CONFIDENCE="${arg#*=}"
+      ;;
+    --min-confidence)
+      # handled as next argument
+      ;;
+    --domains=*)
+      DOMAINS="${arg#*=}"
+      ;;
+    --domains)
+      # handled as next argument
+      ;;
+    --stop-on-blocked)
+      STOP_ON_BLOCKED=true
+      ;;
+    --feedback-at-end)
+      FEEDBACK_AT_END=true
+      ;;
+    --feedback-at-end=false|--no-feedback-at-end)
+      FEEDBACK_AT_END=false
+      ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      echo ""
+      echo "Usage: /df-ff [--max-runs N] [--min-confidence N] [--domains list] [--stop-on-blocked] [--feedback-at-end false]"
+      exit 1
+      ;;
+  esac
+done
+```
+
+### Step 3: Validate Argument Values
+
+```bash
+# Hard cap: max-runs cannot exceed 50
+if [ "$MAX_RUNS" -gt 50 ]; then
+  echo "Warning: --max-runs capped at 50 (requested: $MAX_RUNS)"
+  MAX_RUNS=50
+fi
+
+# Safety warning for large runs
+if [ "$MAX_RUNS" -gt 20 ]; then
+  echo "Note: Running $MAX_RUNS iterations may take significant time."
+  echo "Press Ctrl+C to cancel at any time (completed runs will be preserved)."
+  echo ""
+fi
+
+# Validate min-confidence is 0-100
+if [ "$MIN_CONFIDENCE" -lt 0 ] || [ "$MIN_CONFIDENCE" -gt 100 ]; then
+  echo "Error: --min-confidence must be between 0 and 100 (got: $MIN_CONFIDENCE)" >&2
+  exit 1
+fi
+```
+
+### Step 4: Print Start Summary
+
+Before delegating to the skill, print a clear summary of what will run:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+/df-ff  Fast-Forward Learning
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Configuration:
+  Max runs:       [MAX_RUNS]
+  Min confidence: [MIN_CONFIDENCE]%
+  Domains:        [DOMAINS or "all"]
+  Stop on blocked:[STOP_ON_BLOCKED]
+  Feedback at end:[FEEDBACK_AT_END]
+
+Starting autonomous learning loop...
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+### Step 5: Invoke deepfield-ff Skill
+
+Delegate all learning orchestration to the `deepfield-ff` skill. Pass all parsed parameters:
+
+```
+Invoke skill: deepfield-ff
+Parameters:
+  - max-runs: ${MAX_RUNS}
+  - min-confidence: ${MIN_CONFIDENCE}
+  - domains: ${DOMAINS} (empty = all)
+  - stop-on-blocked: ${STOP_ON_BLOCKED}
+  - feedback-at-end: ${FEEDBACK_AT_END}
+```
+
+The skill handles all learning logic, stop condition evaluation, progress reporting, staging area creation, and the final summary report.
+
+## Error Messages
+
+| Condition | Message |
+|-----------|---------|
+| No `deepfield/` directory | `No deepfield/ directory found. Run /df-init first.` |
+| No Run 0 | `Bootstrap (Run 0) not complete. Run /df-continue first.` |
+| No learning plan | `No learning plan found. Bootstrap may have failed. Check /df-status.` |
+| Unknown argument | `Unknown argument: <arg>` + usage line |
+| max-runs > 50 | `Warning: --max-runs capped at 50 (requested: N)` |
+| min-confidence out of range | `Error: --min-confidence must be between 0 and 100 (got: N)` |
+
+## Stop Conditions (handled by skill)
+
+The skill stops when ANY of these fire (in evaluation order):
+
+1. **CONFIDENCE_REACHED**: All HIGH-priority topics (in scoped domains) >= min-confidence
+2. **MAX_RUNS_HIT**: Session has executed max-runs iterations
+3. **DIMINISHING_RETURNS**: 2+ consecutive runs with < 5% net confidence change
+4. **BLOCKED**: All HIGH-priority topics blocked AND --stop-on-blocked is set
+5. **DOMAIN_RESTRUCTURE**: Domain count changed by > 3 since session start
+
+## Relationship to Other Commands
+
+- **`/df-continue`**: Smart router — detects state and routes to appropriate action. Use when unsure what to do next.
+- **`/df-iterate`**: Single autonomous learning cycle with stop condition evaluation. Use for step-by-step control.
+- **`/df-ff`**: Multi-run batch mode. Use when you want to run many cycles without intervention.
+- **`/df-status`**: Check current confidence levels and learning plan state.
+- **`/df-output`**: Snapshot drafts to versioned output after learning is complete.
+
+## Tips for Claude
+
+- Always validate prerequisites before invoking the skill — do not silently skip validation
+- Print the start summary clearly so users know what configuration is active
+- If the user seems confused about when to use /df-ff vs /df-iterate, explain: /df-ff is for batch runs, /df-iterate is for step-by-step control
+- After completion, if stop reason is CONFIDENCE_REACHED, proactively suggest `/df-output` to snapshot the knowledge
+- If user cancels mid-session (Ctrl+C), note that all completed runs are preserved in `deepfield/wip/run-N/`

--- a/plugin/scripts/check-confidence.js
+++ b/plugin/scripts/check-confidence.js
@@ -1,0 +1,320 @@
+#!/usr/bin/env node
+/**
+ * check-confidence.js - Compute confidence scores from run configs and learning plan
+ *
+ * Usage: check-confidence.js <deepfield-dir> [--domains <comma-separated>] [--threshold <number>]
+ *
+ * Example:
+ *   node check-confidence.js ./deepfield --threshold 80
+ *   node check-confidence.js ./deepfield --domains auth,api --threshold 85
+ *
+ * Output JSON:
+ * {
+ *   "overallConfidence": 72,
+ *   "thresholdMet": false,
+ *   "threshold": 80,
+ *   "topics": [
+ *     { "name": "Authentication", "priority": "HIGH", "confidence": 85, "meetsThreshold": true }
+ *   ],
+ *   "highPriorityCount": 2,
+ *   "highPriorityMeetingThreshold": 1,
+ *   "domainsFilter": ["auth"]
+ * }
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+const args = process.argv.slice(2);
+
+if (args.length === 0 || args[0] === '--help' || args[0] === '-h') {
+  process.stderr.write(
+    'Usage: check-confidence.js <deepfield-dir> [--domains <list>] [--threshold <n>]\n'
+  );
+  process.exit(1);
+}
+
+const deepfieldDir = args[0];
+let domainsFilter = [];
+let threshold = 80;
+
+for (let i = 1; i < args.length; i++) {
+  if (args[i] === '--domains' && args[i + 1]) {
+    domainsFilter = args[i + 1].split(',').map(d => d.trim().toLowerCase()).filter(Boolean);
+    i++;
+  } else if (args[i] === '--threshold' && args[i + 1]) {
+    const parsed = parseInt(args[i + 1], 10);
+    if (!isNaN(parsed) && parsed >= 0 && parsed <= 100) {
+      threshold = parsed;
+    }
+    i++;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  // Validate deepfield directory
+  if (!fs.existsSync(deepfieldDir)) {
+    process.stderr.write(`Error: Directory not found: ${deepfieldDir}\n`);
+    process.exit(1);
+  }
+
+  const wipDir = path.join(deepfieldDir, 'wip');
+  if (!fs.existsSync(wipDir)) {
+    process.stderr.write(`Error: No wip/ directory found in ${deepfieldDir}\n`);
+    process.exit(1);
+  }
+
+  // Find the highest-numbered completed run config (run-N.config.json, N >= 1)
+  const runConfig = findLatestRunConfig(wipDir);
+  if (!runConfig) {
+    const result = {
+      error: 'No completed learning runs found. Run /df-iterate or /df-ff first.'
+    };
+    process.stderr.write(result.error + '\n');
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    process.exit(1);
+  }
+
+  // Extract topic confidence from run config
+  const topicsFromConfig = extractTopicsFromRunConfig(runConfig.data);
+
+  // If no topic data in run config, try to read from learning plan
+  const learningPlanPath = path.join(deepfieldDir, 'wip', 'learning-plan.md');
+  const learningPlanTopics = readLearningPlanTopics(learningPlanPath);
+
+  // Merge: prefer run config confidence values, fall back to learning plan values
+  const allTopics = mergeTopics(topicsFromConfig, learningPlanTopics);
+
+  // Apply domain filter
+  const filteredTopics = applyDomainFilter(allTopics, domainsFilter);
+
+  if (domainsFilter.length > 0 && filteredTopics.length === 0) {
+    const result = {
+      error: `No topics found matching domain filter: ${domainsFilter.join(', ')}`,
+      domainsFilter
+    };
+    process.stderr.write(result.error + '\n');
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    process.exit(1);
+  }
+
+  // Compute confidence scores
+  const highPriorityTopics = filteredTopics.filter(t => t.priority === 'HIGH');
+  const highPriorityCount = highPriorityTopics.length;
+
+  // Annotate each topic with meetsThreshold
+  const annotatedTopics = filteredTopics.map(t => ({
+    ...t,
+    meetsThreshold: t.confidence >= threshold
+  }));
+
+  const highPriorityMeetingThreshold = highPriorityTopics.filter(
+    t => t.confidence >= threshold
+  ).length;
+
+  // Overall confidence = average confidence across filtered topics (or 0 if none)
+  const overallConfidence =
+    filteredTopics.length > 0
+      ? Math.round(
+          filteredTopics.reduce((sum, t) => sum + t.confidence, 0) / filteredTopics.length
+        )
+      : 0;
+
+  // Threshold is met when ALL high-priority topics (in scope) meet it
+  const thresholdMet =
+    highPriorityCount > 0 && highPriorityMeetingThreshold === highPriorityCount;
+
+  const result = {
+    overallConfidence,
+    thresholdMet,
+    threshold,
+    topics: annotatedTopics,
+    highPriorityCount,
+    highPriorityMeetingThreshold,
+    domainsFilter,
+    latestRunNumber: runConfig.runNumber
+  };
+
+  process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Find the highest-numbered run-N.config.json (N >= 1) in wip/
+ * Returns { runNumber, data } or null if none found.
+ */
+function findLatestRunConfig(wipDir) {
+  let entries;
+  try {
+    entries = fs.readdirSync(wipDir);
+  } catch (err) {
+    return null;
+  }
+
+  // Match directories named run-N
+  const runDirs = entries
+    .filter(e => /^run-\d+$/.test(e))
+    .map(e => ({
+      name: e,
+      num: parseInt(e.replace('run-', ''), 10)
+    }))
+    .filter(e => e.num >= 1) // Skip run-0 (bootstrap)
+    .sort((a, b) => b.num - a.num); // Highest first
+
+  for (const dir of runDirs) {
+    const configPath = path.join(wipDir, dir.name, `${dir.name}.config.json`);
+    if (fs.existsSync(configPath)) {
+      try {
+        const content = fs.readFileSync(configPath, 'utf8');
+        const data = JSON.parse(content);
+        // Only use completed runs
+        if (data.status === 'completed') {
+          return { runNumber: dir.num, data };
+        }
+      } catch (_) {
+        // Skip malformed configs
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Extract per-topic confidence from run config's confidenceChanges field.
+ * Returns array of { name, priority, confidence, domain }
+ */
+function extractTopicsFromRunConfig(runConfig) {
+  const confidenceChanges = runConfig.confidenceChanges || {};
+  const topics = [];
+
+  for (const [topicName, change] of Object.entries(confidenceChanges)) {
+    const confidence = typeof change.after === 'number' ? change.after : 0;
+    topics.push({
+      name: topicName,
+      priority: change.priority || 'HIGH', // Default to HIGH if not specified
+      confidence,
+      domain: change.domain || null
+    });
+  }
+
+  return topics;
+}
+
+/**
+ * Parse learning plan markdown to extract topic names, priorities, and confidence.
+ * Falls back gracefully — returns empty array if file missing or unparseable.
+ *
+ * Expected format lines like:
+ *   - **TopicName** (HIGH, 65%)
+ *   | TopicName | HIGH | 65% |
+ */
+function readLearningPlanTopics(learningPlanPath) {
+  if (!fs.existsSync(learningPlanPath)) {
+    return [];
+  }
+
+  let content;
+  try {
+    content = fs.readFileSync(learningPlanPath, 'utf8');
+  } catch (_) {
+    return [];
+  }
+
+  const topics = [];
+
+  // Pattern: | Topic Name | HIGH | 65% | or similar table rows
+  const tableRowPattern = /\|\s*([^|]+?)\s*\|\s*(HIGH|MEDIUM|LOW)\s*\|\s*(\d+)%/gi;
+  let match;
+  while ((match = tableRowPattern.exec(content)) !== null) {
+    const name = match[1].trim();
+    const priority = match[2].toUpperCase();
+    const confidence = parseInt(match[3], 10);
+    if (name && !isNaN(confidence)) {
+      topics.push({ name, priority, confidence, domain: null });
+    }
+  }
+
+  // Pattern: - **TopicName** (HIGH, 65%)
+  const listPattern = /\*\*([^*]+)\*\*\s*\((HIGH|MEDIUM|LOW)[^)]*(\d+)%\)/gi;
+  while ((match = listPattern.exec(content)) !== null) {
+    const name = match[1].trim();
+    const priority = match[2].toUpperCase();
+    const confidence = parseInt(match[3], 10);
+    if (name && !isNaN(confidence) && !topics.find(t => t.name === name)) {
+      topics.push({ name, priority, confidence, domain: null });
+    }
+  }
+
+  return topics;
+}
+
+/**
+ * Merge topics from run config and learning plan.
+ * Run config values take precedence (they're more accurate/recent).
+ */
+function mergeTopics(runConfigTopics, learningPlanTopics) {
+  const merged = new Map();
+
+  // Start with learning plan data (lower priority)
+  for (const t of learningPlanTopics) {
+    merged.set(t.name, { ...t });
+  }
+
+  // Override with run config data (higher priority)
+  for (const t of runConfigTopics) {
+    if (merged.has(t.name)) {
+      merged.set(t.name, { ...merged.get(t.name), ...t });
+    } else {
+      merged.set(t.name, { ...t });
+    }
+  }
+
+  return Array.from(merged.values());
+}
+
+/**
+ * Apply domain filter to topics list.
+ * If filter is empty, return all topics.
+ * Matches on topic name (substring) or domain field.
+ */
+function applyDomainFilter(topics, domainsFilter) {
+  if (domainsFilter.length === 0) {
+    return topics;
+  }
+
+  return topics.filter(t => {
+    const topicNameLower = t.name.toLowerCase();
+    const topicDomainLower = (t.domain || '').toLowerCase();
+
+    return domainsFilter.some(
+      d => topicNameLower.includes(d) || topicDomainLower.includes(d) || d.includes(topicNameLower)
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Run
+// ---------------------------------------------------------------------------
+
+try {
+  main();
+} catch (err) {
+  process.stderr.write(`Unexpected error: ${err.message}\n`);
+  process.stderr.write(err.stack + '\n');
+  process.exit(1);
+}

--- a/plugin/skills/deepfield-ff.md
+++ b/plugin/skills/deepfield-ff.md
@@ -1,0 +1,409 @@
+---
+name: Deepfield Fast-Forward
+description: Autonomous multi-run learning loop — runs multiple iterations without user feedback between runs, stopping when confidence thresholds or safety limits are reached
+trigger_mode: command
+user_invocable: false
+---
+
+# Purpose
+
+This skill orchestrates multiple autonomous learning iterations (fast-forward mode) without pausing for user feedback between runs. It invokes the `deepfield-iterate` skill logic in single-run mode repeatedly, evaluating stop conditions after each run, until any stop condition fires.
+
+# Input Parameters
+
+This skill receives the following parameters from the `/df-ff` command:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `max-runs` | integer | 10 | Maximum iterations to execute in this session (hard cap: 50) |
+| `min-confidence` | integer | 80 | Minimum confidence % for HIGH-priority topics to achieve |
+| `domains` | string[] | [] (all) | Domain names to focus on; empty = all domains |
+| `stop-on-blocked` | boolean | false | Stop if all high-priority scoped topics are blocked |
+| `feedback-at-end` | boolean | true | Prompt for feedback after all runs complete |
+
+# Prerequisites
+
+Before starting the loop, verify these are satisfied (the `/df-ff` command validates these, but double-check):
+
+1. `deepfield/` directory exists
+2. `deepfield/wip/run-0/run-0.config.json` exists (bootstrap complete)
+3. `deepfield/wip/learning-plan.md` exists
+
+# Phase 0: Domain Filter Validation
+
+If `--domains` filter was provided, validate domain names against the domain index.
+
+## Read Domain Index
+
+```bash
+# Check domain index exists
+if [ -f "./deepfield/wip/domain-index.md" ]; then
+  # Extract domain names from domain-index.md
+  # Domains are listed as headings: ## Domain: auth or ## auth
+  grep -i "^##" ./deepfield/wip/domain-index.md
+fi
+```
+
+## Validate Each Specified Domain
+
+For each domain name in the filter:
+
+1. Check if it appears (case-insensitive substring match) in domain-index.md
+2. If no match found: print warning `"Domain 'xyz' not found in domain index. Known domains: <list>"`
+3. Remove unknown domains from filter, keep valid ones
+4. If ALL specified domains are unknown (no valid domains remain):
+   - Print error: `"No valid domains found matching filter. Check /df-status for domain list."`
+   - Exit without running any iterations
+
+# Phase 1: Session Initialization
+
+## Record Session Start State
+
+Before the loop begins, record the starting confidence of all topics using the confidence script:
+
+```bash
+node ${CLAUDE_PLUGIN_ROOT}/scripts/check-confidence.js ./deepfield \
+  $([ -n "$DOMAINS" ] && echo "--domains $DOMAINS") \
+  --threshold $MIN_CONFIDENCE
+```
+
+Parse the JSON output to get the starting confidence baseline for the final report.
+
+## Initialize Session Counters
+
+```
+sessionRunCount = 0
+sessionStartRun = <current highest run number + 1>
+sessionStartDomainCount = <count of domains in domain-index.md>
+previousRunConfidenceNet = null
+twoRunsLowProgress = false
+```
+
+# Phase 2: Fast-Forward Loop
+
+```
+While sessionRunCount < max-runs:
+  1. Execute single learning iteration (Run N)
+  2. Print per-run progress line
+  3. Evaluate stop conditions
+  4. If any stop condition fires → break with stopReason
+  5. sessionRunCount++
+  6. Continue
+```
+
+## Step 2A: Execute Single Learning Iteration
+
+Invoke the `deepfield-iterate` skill in **single-run mode** (`--once`):
+
+- If `domains` filter is set, pass `--focus=<primary-domain>` (first domain in filter)
+- The iterate skill handles: scanning, learning, synthesis, run config update, learning plan update
+- Do NOT pause for user feedback — proceed immediately after the run completes
+
+**IMPORTANT**: In fast-forward mode, suppress all interactive prompts. After each run, read the updated run config to get results rather than waiting for user input.
+
+After the run completes, read the new run config to get confidence changes:
+
+```javascript
+// Find the newly completed run config
+const latestRunConfig = findLatestRunConfig('./deepfield/wip/')
+const confidenceChanges = latestRunConfig.confidenceChanges || {}
+```
+
+## Step 2B: Print Per-Run Progress Line
+
+After each run completes, print a compact progress line:
+
+```
+Run N complete | Authentication: 65%→85% | API Structure: 50%→70% | Data Flow: 30%→50%
+```
+
+Format:
+```
+Run <N> complete | <topic1>: <before>%→<after>% | <topic2>: <before>%→<after>% | ...
+```
+
+If no confidence changes were recorded, print:
+```
+Run <N> complete | (no confidence data recorded)
+```
+
+## Step 2C: Evaluate Stop Conditions
+
+After each run, evaluate conditions in this order:
+
+### Stop Condition 1: CONFIDENCE_REACHED
+
+```bash
+# Run confidence check
+CONFIDENCE_JSON=$(node ${CLAUDE_PLUGIN_ROOT}/scripts/check-confidence.js \
+  ./deepfield \
+  $([ -n "$DOMAINS" ] && echo "--domains $DOMAINS") \
+  --threshold $MIN_CONFIDENCE)
+
+THRESHOLD_MET=$(echo $CONFIDENCE_JSON | node -e "
+  let d=''; process.stdin.on('data',c=>d+=c);
+  process.stdin.on('end',()=>console.log(JSON.parse(d).thresholdMet))
+")
+
+if [ "$THRESHOLD_MET" = "true" ]; then
+  STOP_REASON="CONFIDENCE_REACHED"
+  break
+fi
+```
+
+### Stop Condition 2: MAX_RUNS_HIT
+
+```javascript
+if (sessionRunCount >= maxRuns) {
+  stopReason = "MAX_RUNS_HIT"
+  break
+}
+```
+
+(Evaluated after incrementing sessionRunCount at end of loop iteration)
+
+### Stop Condition 3: DIMINISHING_RETURNS
+
+After each run, compute total net confidence change across all focus topics:
+
+```javascript
+const netChange = Object.values(confidenceChanges).reduce((sum, c) => {
+  return sum + ((c.after || 0) - (c.before || 0))
+}, 0)
+
+// If this run had < 5% net change
+const lowProgress = netChange < 5
+
+if (lowProgress && previousRunWasLowProgress) {
+  stopReason = "DIMINISHING_RETURNS"
+  break
+}
+
+previousRunWasLowProgress = lowProgress
+```
+
+### Stop Condition 4: BLOCKED (only if --stop-on-blocked)
+
+Only evaluated when `stop-on-blocked` parameter is true:
+
+```javascript
+if (stopOnBlocked) {
+  const highPriorityTopics = learningPlan.topics.filter(t => t.priority === "HIGH")
+  const scopedTopics = domainsFilter.length > 0
+    ? highPriorityTopics.filter(t => domainsFilter.some(d => t.name.toLowerCase().includes(d)))
+    : highPriorityTopics
+
+  const allBlocked = scopedTopics.length > 0 && scopedTopics.every(t => t.status === "blocked")
+
+  if (allBlocked) {
+    stopReason = "BLOCKED"
+    break
+  }
+}
+```
+
+### Stop Condition 5: DOMAIN_RESTRUCTURE
+
+```javascript
+const currentDomainCount = countDomainsInIndex('./deepfield/wip/domain-index.md')
+
+if (Math.abs(currentDomainCount - sessionStartDomainCount) > 3) {
+  stopReason = "DOMAIN_RESTRUCTURE"
+  break
+}
+```
+
+# Phase 3: On Loop Exit
+
+## Step 3A: Create Staging Area
+
+**CRITICAL: Always create the next staging area regardless of stop reason.**
+
+After the loop exits, determine the next run number (last completed run + 1) and create the staging area:
+
+```bash
+LAST_RUN_N=<last completed run number>
+NEXT_STAGING=$((LAST_RUN_N + 1))
+
+mkdir -p "./deepfield/source/run-${NEXT_STAGING}-staging/sources"
+```
+
+### Write README.md
+
+Create `deepfield/source/run-${NEXT_STAGING}-staging/README.md`:
+
+```markdown
+# Run ${NEXT_STAGING} Staging Area
+
+This is where you add new sources and feedback for the next learning run.
+
+## How to use
+
+1. Drop new source files into the `sources/` subdirectory
+2. Edit `feedback.md` to answer open questions or provide guidance
+3. Run `/df-continue` when ready to resume learning
+
+## What was learned in the last fast-forward session
+
+<brief summary of what the ff session covered and its stop reason>
+```
+
+### Write feedback.md
+
+Create `deepfield/source/run-${NEXT_STAGING}-staging/feedback.md` populated with:
+- Open questions from the current learning plan
+- Topics that need more focus (low confidence)
+- Specific sources that would help
+- Any contradictions to clarify
+
+Read these from `deepfield/wip/learning-plan.md` to populate the template.
+
+## Step 3B: Print Final Summary Report
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Fast-Forward Learning Complete
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Runs Executed: [N] runs (Run [X] through Run [Y])
+Stop Reason:   [REASON] — [explanation]
+
+Progress Summary:
+
+Topic                    Before → After  Status
+─────────────────────────────────────────────────
+Authentication           65%   → 85%    ✓ (target: 80%)
+API Structure            50%   → 70%    ↑
+Data Flow                30%   → 50%    ↑
+Background Jobs          15%   → 15%    · (not focused)
+
+HIGH Priority Complete: [X]/[Y] topics >= [min-confidence]%
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Documentation Updated:
+  deepfield/drafts/domains/<updated files>
+
+Next Steps:
+[stop-reason-specific section — see below]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+### Next Steps by Stop Reason
+
+**CONFIDENCE_REACHED:**
+```
+All HIGH priority topics have reached the target confidence of [min-confidence]%.
+
+  /df-output     Snapshot knowledge to versioned output
+  /df-status     Review detailed progress
+  /df-continue   Continue with MEDIUM priority topics
+```
+
+**MAX_RUNS_HIT:**
+```
+Paused after [N] runs (limit: [max-runs]).
+
+Good progress made! To continue learning:
+  1. Review:  deepfield/drafts/ — Updated documentation
+  2. Review:  deepfield/wip/learning-plan.md — Current state
+  3. Add feedback or sources to:
+               deepfield/source/run-[N+1]-staging/
+
+  Then run /df-continue to resume
+  Or run /df-ff --max-runs [n] to run more iterations
+```
+
+**DIMINISHING_RETURNS:**
+```
+Minimal progress detected in the last 2 runs (<5% confidence change each).
+
+Suggestions to break the plateau:
+  - Add new sources with different perspectives
+  - Review:   deepfield/drafts/cross-cutting/unknowns.md
+  - Consider adjusting focus with --domains flag
+  - Snapshot current knowledge: /df-output
+```
+
+**BLOCKED:**
+```
+Blocked: All HIGH-priority topics need additional sources.
+
+Missing sources for blocked topics:
+  [list of topics and their needed sources from learning plan]
+
+Add sources to:
+  deepfield/source/run-[N+1]-staging/sources/
+
+Then run /df-continue
+```
+
+**DOMAIN_RESTRUCTURE:**
+```
+Major domain changes detected (domain count shifted by >3).
+
+Domain structure has changed significantly.
+Please review and confirm:
+  deepfield/wip/domain-index.md
+
+Then run /df-continue to resume with updated structure.
+```
+
+## Step 3C: Feedback Collection Prompt (if feedback-at-end=true)
+
+If `feedback-at-end` is true (default), after the summary report, print:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Review & Feedback
+
+Please review the updated documentation in deepfield/drafts/
+and add any feedback or new sources to:
+
+  deepfield/source/run-[N+1]-staging/feedback.md
+  deepfield/source/run-[N+1]-staging/sources/
+
+Run /df-continue when ready for the next session.
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+If `feedback-at-end` is false, skip this prompt and end silently after the summary.
+
+# Error Handling
+
+## Iterate Skill Failure
+
+If an individual run fails (agent error, script error, etc.):
+- Mark the run as failed in its config
+- Do NOT continue to next run
+- Print:
+  ```
+  Run [N] failed: [error details]
+
+  The fast-forward session has been paused. Partial results are in:
+    deepfield/wip/run-[N]/
+
+  Fix the issue and retry with /df-ff or continue with /df-continue.
+  ```
+
+## Confidence Script Failure
+
+If `check-confidence.js` fails:
+- Treat confidence as 0 (threshold not met)
+- Log a warning: `"Warning: Could not compute confidence scores. Continuing..."`
+- Do NOT stop the loop due to script failure alone
+- Diminishing returns check uses 0 as the net change for that run
+
+## No Topics in Domain Filter
+
+Already handled in Phase 0 — exit before loop starts.
+
+# Implementation Notes for Claude
+
+- **No interactive prompts between runs**: Do not ask the user anything mid-loop. Read state from files, proceed autonomously.
+- **Progress visibility**: Print each run's progress line immediately after completion — users watching the session should see activity.
+- **State preservation**: Each run's results are in `deepfield/wip/run-N/`. Even if the ff session is cancelled mid-run, previous runs are preserved.
+- **Confidence data source**: Always use `check-confidence.js` output for stop condition 1. For diminishing returns, use the raw `confidenceChanges` from the run config JSON directly.
+- **Loop counter**: `sessionRunCount` is the number of runs completed in *this ff session*, not the global run number.
+- **Safety warning**: If `max-runs > 20`, print a warning at session start: `"Note: Running [max-runs] iterations may take significant time. Press Ctrl+C to cancel at any time."`


### PR DESCRIPTION
Closes #26. Implements autonomous multi-run learning loop.

## Summary

- Adds `/df-ff` command for batch autonomous learning without user intervention between runs
- Adds `deepfield-ff` skill that orchestrates the multi-run loop with 5 stop conditions: confidence reached, max runs hit, diminishing returns, blocked, domain restructure
- Adds `check-confidence.js` script (CJS) that reads run configs and learning plan to compute per-domain confidence scores

## Stop Conditions

1. **CONFIDENCE_REACHED** — All HIGH-priority topics >= `--min-confidence` (default 80%)
2. **MAX_RUNS_HIT** — Session executed `--max-runs` iterations (default 10, hard cap 50)
3. **DIMINISHING_RETURNS** — 2 consecutive runs with < 5% net confidence change
4. **BLOCKED** — All in-scope topics blocked AND `--stop-on-blocked` flag set
5. **DOMAIN_RESTRUCTURE** — Domain count shifted by > 3 since session start

## New Files

- `plugin/commands/df-ff.md` — Command with argument parsing, prerequisite validation, and start summary
- `plugin/skills/deepfield-ff.md` — Skill with full loop logic, per-run progress lines, staging area creation, and final report
- `plugin/scripts/check-confidence.js` — Confidence scoring script using CJS (`require`/`module.exports`)
- `openspec/changes/df-ff-command/` — OpenSpec artifacts (proposal, design, specs, tasks)

## Test plan

- [ ] `/df-ff` with no prerequisites exits with clear error messages
- [ ] `/df-ff --max-runs 100` warns and caps at 50
- [ ] `/df-ff --min-confidence 101` exits with out-of-range error
- [ ] `/df-ff --unknown-flag` exits with usage message
- [ ] `check-confidence.js` returns `thresholdMet: true` when all HIGH topics >= threshold
- [ ] `check-confidence.js` with `--domains` filter only evaluates matching topics
- [ ] `check-confidence.js` exits with error when no completed runs exist
- [ ] ff loop stops on CONFIDENCE_REACHED and reports correct next steps
- [ ] ff loop stops on DIMINISHING_RETURNS after 2 low-progress runs
- [ ] Staging area is always created on loop exit regardless of stop reason
- [ ] Feedback prompt appears by default; suppressed with `--feedback-at-end false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)