### PR TITLE
fix: read user-provided source files during learning

### DIFF
--- a/openspec/changes/fix-source-files-ignored/.openspec.yaml
+++ b/openspec/changes/fix-source-files-ignored/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-04

--- a/openspec/changes/fix-source-files-ignored/design.md
+++ b/openspec/changes/fix-source-files-ignored/design.md
@@ -1,0 +1,64 @@
+## Context
+
+The `deepfield-iterate` skill drives all learning cycles. In Step 3 (Incremental Scanning) it hashes files under `deepfield/source/baseline/repos/` to build `filesToRead`, then passes that list to the learner agent. Files that users place in `deepfield/source/source-doc/` (or any non-repo subdirectory of `source/`) are never discovered or read.
+
+Binary document formats (PDF, PPTX, DOCX) cannot be read as raw text; they require extraction libraries to produce usable plain text before they can be passed to an agent.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Detect all user-provided files under `deepfield/source/` (excluding `baseline/repos/` and staging directories)
+- Extract plain-text content from PDF, DOCX, and PPTX files
+- Pass extracted content to the learner agent as additional context each run
+- Warn clearly when a file format cannot be processed
+
+**Non-Goals:**
+- OCR for image-only PDFs (out of scope; warn and skip)
+- Extracting embedded images from Office documents
+- Re-extracting source docs that have not changed between runs (hash-based skip is a future optimisation; for now always re-extract)
+- Modifying the classifier agent or df-input command
+
+## Decisions
+
+### Decision 1: New script `scan-source-docs.js`
+
+Extraction logic is placed in a dedicated CJS script (`plugin/scripts/scan-source-docs.js`) rather than inline in the skill, consistent with the project's Command → Skill → Script → Agent pattern. The script is invoked by the skill and writes output to `deepfield/wip/run-N/source-docs/`.
+
+Alternatives considered:
+- Inline extraction in the skill: violates the architecture pattern and makes the skill harder to test.
+- Separate agent for extraction: unnecessary for deterministic text extraction; agents are reserved for AI reasoning tasks.
+
+### Decision 2: Extract to markdown files, not a single blob
+
+Each source document gets its own `<filename>.md` file inside `deepfield/wip/run-N/source-docs/`. This keeps individual file provenance clear, lets the learner agent cite specific source documents, and makes the extracted content inspectable by the user.
+
+### Decision 3: Extraction libraries
+
+| Format | Library | Rationale |
+|--------|---------|-----------|
+| PDF | `pdf-parse` | Widely used, no native bindings required |
+| DOCX | `mammoth` | Produces clean text, already referenced in issue |
+| PPTX | `pptx-parser` | Provides per-slide text access |
+| MD/TXT/RST | Node.js `fs` | Direct read, no extraction needed |
+
+### Decision 4: Include extracted docs alongside repo files in `filesToRead`
+
+The skill appends the paths of all generated `source-docs/*.md` files to `filesToRead` before launching the learner agent. This requires minimal changes to the existing skill flow.
+
+## Risks / Trade-offs
+
+- **Large documents slow down the agent context window** → Mitigation: truncate extracted text to 50 000 characters per file and note the truncation in the markdown header.
+- **`pdf-parse` may fail on encrypted or scan-only PDFs** → Mitigation: catch errors per file, write a warning stub markdown, continue processing remaining files.
+- **`pptx-parser` API may differ from examples in issue** → Mitigation: script verifies available API at runtime and falls back gracefully with a warning.
+- **Re-extracting every run is wasteful for large doc sets** → Acceptable for v1; hash-based skip can be added later.
+
+## Migration Plan
+
+1. Add `pdf-parse`, `mammoth`, `pptx-parser` to `plugin/package.json` dependencies.
+2. Add `plugin/scripts/scan-source-docs.js`.
+3. Update `plugin/skills/deepfield-iterate.md` Step 3 to call the script and include results.
+4. No state format changes; no migration required for existing deepfield projects.
+
+## Open Questions
+
+- None blocking implementation.

--- a/openspec/changes/fix-source-files-ignored/proposal.md
+++ b/openspec/changes/fix-source-files-ignored/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Users place PDF, PPTX, and other document files in `deepfield/source/source-doc/` expecting Deepfield to read them during learning, but the learning skill only scans baseline repository code — it never reads user-provided source documents. This silently discards answers to open questions and breaks the core workflow.
+
+## What Changes
+
+- Add a `scan-source-docs.js` script that discovers all files under `deepfield/source/` (excluding `baseline/repos/` and staging dirs) and extracts readable text from them
+- Support `.md`, `.txt`, `.rst` (direct read), `.pdf` (text extraction via `pdf-parse`), `.docx` (extraction via `mammoth`), and `.pptx` (slide text via `pptx-parser`); warn and skip unsupported binary types
+- Save extracted content as markdown files in `deepfield/wip/run-N/source-docs/` so they are available to the learner agent
+- Update `deepfield-iterate` skill (Step 3 – Incremental Scanning) to invoke `scan-source-docs.js` and include the resulting markdown files in `filesToRead` passed to the learner agent
+- Report what was found, extracted, and any unsupported-format warnings to the user during iteration
+
+## Capabilities
+
+### New Capabilities
+- `source-doc-extraction`: Detect and extract text from user-provided source documents (PDF, DOCX, PPTX, plain text) and make content available to the learning agent
+
+### Modified Capabilities
+- `plugin-skills`: The `deepfield-iterate` skill's scanning step is extended to include source-doc extraction — the requirement that "files to read" covers user-provided documents is new spec-level behaviour
+
+## Impact
+
+- **New script**: `plugin/scripts/scan-source-docs.js` (Node.js CJS)
+- **Modified skill**: `plugin/skills/deepfield-iterate.md` — Step 3 (Incremental Scanning) updated to call `scan-source-docs.js` and include results in `filesToRead`
+- **New dependencies**: `pdf-parse`, `mammoth`, `pptx-parser` added to `plugin/package.json`
+- No breaking changes to existing commands or state format

--- a/openspec/changes/fix-source-files-ignored/specs/plugin-skills/spec.md
+++ b/openspec/changes/fix-source-files-ignored/specs/plugin-skills/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+
+### Requirement: deepfield-iterate skill SHALL include user source documents in learning scan
+The `deepfield-iterate` skill MUST invoke `scan-source-docs.js` during Step 3 (Incremental Scanning) and append the resulting markdown file paths to `filesToRead` before launching the learner agent. This ensures user-provided documents in `deepfield/source/` are read during every learning iteration.
+
+#### Scenario: Source docs included in files to read
+- **WHEN** the iterate skill executes Step 3
+- **THEN** it runs `scan-source-docs.js` with the current run number
+- **THEN** the JSON index of extracted markdown paths is read
+- **THEN** those paths are appended to `filesToRead`
+- **THEN** the learner agent receives the extracted content alongside repository code
+
+#### Scenario: No source docs present
+- **WHEN** `deepfield/source/` contains no user-provided files
+- **THEN** `scan-source-docs.js` produces an empty JSON index
+- **THEN** `filesToRead` is unchanged
+- **THEN** the skill continues without error
+
+#### Scenario: Extraction warnings reported to user
+- **WHEN** `scan-source-docs.js` encounters files it cannot process
+- **THEN** the skill surfaces the printed summary to the user
+- **THEN** the skill does NOT abort the learning cycle due to extraction warnings

--- a/openspec/changes/fix-source-files-ignored/specs/source-doc-extraction/spec.md
+++ b/openspec/changes/fix-source-files-ignored/specs/source-doc-extraction/spec.md
@@ -1,0 +1,75 @@
+## ADDED Requirements
+
+### Requirement: Script SHALL discover all user-provided source files
+The `scan-source-docs.js` script MUST recursively list all files under `deepfield/source/` while excluding `baseline/repos/` subdirectories and any directory matching `run-*-staging`.
+
+#### Scenario: Files in source-doc are discovered
+- **WHEN** the script runs and `deepfield/source/source-doc/` contains files
+- **THEN** all files in that directory are included in the discovered list
+
+#### Scenario: Baseline repo files are excluded
+- **WHEN** `deepfield/source/baseline/repos/` contains code files
+- **THEN** those files are NOT included in the discovered list
+
+#### Scenario: Staging directories are excluded
+- **WHEN** `deepfield/source/run-2-staging/` exists with content
+- **THEN** those files are NOT included in the discovered list
+
+### Requirement: Script SHALL extract text from supported document formats
+The script MUST extract plain text from PDF (`.pdf`), DOCX (`.docx`), and PPTX (`.pptx`) files using appropriate libraries, and read plain text directly from `.md`, `.txt`, and `.rst` files.
+
+#### Scenario: PDF text extraction
+- **WHEN** a `.pdf` file with a text layer is discovered
+- **THEN** the script extracts the text content
+- **THEN** a markdown file is written to `deepfield/wip/run-N/source-docs/<filename>.md` containing the extracted text and a header noting the original file path and page count
+
+#### Scenario: DOCX text extraction
+- **WHEN** a `.docx` file is discovered
+- **THEN** the script extracts the raw text via mammoth
+- **THEN** a markdown file is written to `deepfield/wip/run-N/source-docs/<filename>.md`
+
+#### Scenario: PPTX text extraction
+- **WHEN** a `.pptx` file is discovered
+- **THEN** the script extracts text from each slide
+- **THEN** a markdown file is written to `deepfield/wip/run-N/source-docs/<filename>.md` with per-slide sections
+
+#### Scenario: Plain text direct read
+- **WHEN** a `.md`, `.txt`, or `.rst` file is discovered
+- **THEN** the file content is copied as-is into the output markdown file
+
+### Requirement: Script SHALL truncate very large extracted content
+Extracted text exceeding 50 000 characters MUST be truncated to that limit and the markdown output MUST include a note that the content was truncated.
+
+#### Scenario: Large PDF is truncated
+- **WHEN** a PDF produces more than 50 000 characters of extracted text
+- **THEN** the written markdown contains only the first 50 000 characters
+- **THEN** a truncation notice is appended to the markdown header
+
+### Requirement: Script SHALL handle extraction failures gracefully
+When a file cannot be read or extraction fails, the script MUST write a warning stub markdown file and continue processing remaining files. It MUST NOT exit with a non-zero code due to a single file failure.
+
+#### Scenario: Encrypted PDF cannot be parsed
+- **WHEN** `pdf-parse` throws an error on a file
+- **THEN** the script writes a stub markdown noting the file path and failure reason
+- **THEN** the script continues to process remaining files
+
+#### Scenario: Unsupported file format encountered
+- **WHEN** a file with an unrecognised extension (e.g., `.ppt`, `.xls`) is found
+- **THEN** the script writes a stub markdown warning about the unsupported format
+- **THEN** the stub suggests converting the file to PDF or plain text
+
+### Requirement: Script SHALL report a summary of what was processed
+The script MUST print a human-readable summary to stdout listing each processed file, its type, and outcome (extracted / warning / skipped).
+
+#### Scenario: Summary printed after processing
+- **WHEN** the script finishes running
+- **THEN** each discovered file is listed with status (extracted / warning / skipped)
+- **THEN** total counts of extracted, warned, and skipped files are shown
+
+### Requirement: Script SHALL output the list of generated markdown paths as JSON
+The script MUST write a JSON array of absolute paths of all successfully generated markdown files to the path given by the `--output-index` flag, so the calling skill can consume them.
+
+#### Scenario: Output index written
+- **WHEN** the script completes and `--output-index` is provided
+- **THEN** a JSON file is written at that path containing an array of markdown file paths
+- **THEN** the array contains only files that were successfully written (not stubs for failures)

--- a/openspec/changes/fix-source-files-ignored/tasks.md
+++ b/openspec/changes/fix-source-files-ignored/tasks.md
@@ -1,0 +1,23 @@
+## 1. Add Dependencies
+
+- [x] 1.1 Add `pdf-parse`, `mammoth`, and `pptx-parser` to `plugin/package.json` dependencies
+
+## 2. Create `scan-source-docs.js` Script
+
+- [x] 2.1 Create `plugin/scripts/scan-source-docs.js` as a CJS module with CLI entry point accepting `--run-dir <path>` and `--source-dir <path>` and `--output-index <path>` flags
+- [x] 2.2 Implement file discovery: recursively list all files under `deepfield/source/` excluding `baseline/repos/` and directories matching `run-*-staging`
+- [x] 2.3 Implement plain-text read for `.md`, `.txt`, `.rst` files
+- [x] 2.4 Implement PDF extraction using `pdf-parse`, writing output to `<run-dir>/source-docs/<filename>.md` with header (original path, page count)
+- [x] 2.5 Implement DOCX extraction using `mammoth`, writing output to `<run-dir>/source-docs/<filename>.md`
+- [x] 2.6 Implement PPTX extraction using `pptx-parser`, writing per-slide sections to `<run-dir>/source-docs/<filename>.md`
+- [x] 2.7 Implement 50 000-character truncation with truncation notice in the markdown header
+- [x] 2.8 Implement per-file error handling: on failure write a warning stub markdown and continue; unsupported extensions get a stub with conversion suggestions
+- [x] 2.9 Implement stdout summary report (per-file status, totals)
+- [x] 2.10 Write the `--output-index` JSON file containing paths of successfully generated markdown files
+
+## 3. Update `deepfield-iterate` Skill
+
+- [x] 3.1 In `plugin/skills/deepfield-iterate.md` Step 3 (Incremental Scanning), add a sub-step after hash comparison that invokes `scan-source-docs.js` with the current run directory
+- [x] 3.2 Read the JSON index output by `scan-source-docs.js` and append the paths to `filesToRead`
+- [x] 3.3 Surface the script's stdout summary to the user as part of the scan report
+- [x] 3.4 Ensure the skill continues normally when the JSON index is empty (no source docs present)

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -7,6 +7,11 @@
   "peerDependencies": {
     "deepfield": "^1.0.0"
   },
+  "dependencies": {
+    "mammoth": "^1.8.0",
+    "pdf-parse": "^1.1.1",
+    "pptx-parser": "^1.0.0"
+  },
   "keywords": [
     "claude-code",
     "plugin",

--- a/plugin/scripts/scan-source-docs.js
+++ b/plugin/scripts/scan-source-docs.js
@@ -1,0 +1,331 @@
+'use strict';
+
+/**
+ * scan-source-docs.js
+ *
+ * Discovers user-provided source files under deepfield/source/ (excluding
+ * baseline/repos/ and run-*-staging directories), extracts text from
+ * supported document formats, and writes the content as markdown files
+ * to <run-dir>/source-docs/.
+ *
+ * Usage:
+ *   node scan-source-docs.js \
+ *     --source-dir <path-to-deepfield/source> \
+ *     --run-dir    <path-to-deepfield/wip/run-N> \
+ *     --output-index <path-to-output-index.json>
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i++) {
+    if (argv[i] === '--source-dir') args.sourceDir = argv[++i];
+    else if (argv[i] === '--run-dir') args.runDir = argv[++i];
+    else if (argv[i] === '--output-index') args.outputIndex = argv[++i];
+  }
+  return args;
+}
+
+// ---------------------------------------------------------------------------
+// File discovery
+// ---------------------------------------------------------------------------
+
+const EXCLUDED_DIR_PATTERNS = [
+  /^baseline[/\\]repos([/\\]|$)/,  // baseline/repos/...
+  /^run-\d+-staging([/\\]|$)/,     // run-N-staging/...
+];
+
+function shouldExclude(relPath) {
+  return EXCLUDED_DIR_PATTERNS.some(re => re.test(relPath));
+}
+
+function discoverFiles(sourceDir) {
+  const results = [];
+
+  function walk(dir, relBase) {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch (err) {
+      return; // unreadable directory — skip silently
+    }
+    for (const entry of entries) {
+      const relPath = relBase ? path.join(relBase, entry.name) : entry.name;
+      if (shouldExclude(relPath)) continue;
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath, relPath);
+      } else if (entry.isFile()) {
+        results.push({ fullPath, relPath });
+      }
+    }
+  }
+
+  walk(sourceDir, '');
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Text extraction
+// ---------------------------------------------------------------------------
+
+const MAX_CHARS = 50000;
+
+const TEXT_EXTENSIONS = new Set(['.md', '.txt', '.rst']);
+const PDF_EXTENSION = '.pdf';
+const DOCX_EXTENSION = '.docx';
+const PPTX_EXTENSION = '.pptx';
+
+const SUPPORTED_EXTENSIONS = new Set([
+  ...TEXT_EXTENSIONS,
+  PDF_EXTENSION,
+  DOCX_EXTENSION,
+  PPTX_EXTENSION,
+]);
+
+function truncate(text, filePath) {
+  if (text.length <= MAX_CHARS) return { text, truncated: false };
+  return {
+    text: text.slice(0, MAX_CHARS),
+    truncated: true,
+  };
+}
+
+async function extractText(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+
+  // --- Plain text ---
+  if (TEXT_EXTENSIONS.has(ext)) {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    return { type: 'text', text: raw };
+  }
+
+  // --- PDF ---
+  if (ext === PDF_EXTENSION) {
+    const pdfParse = require('pdf-parse');
+    const buffer = fs.readFileSync(filePath);
+    const data = await pdfParse(buffer);
+    return { type: 'pdf', text: data.text, pages: data.numpages };
+  }
+
+  // --- DOCX ---
+  if (ext === DOCX_EXTENSION) {
+    const mammoth = require('mammoth');
+    const result = await mammoth.extractRawText({ path: filePath });
+    return { type: 'docx', text: result.value };
+  }
+
+  // --- PPTX ---
+  if (ext === PPTX_EXTENSION) {
+    const pptxParser = require('pptx-parser');
+    // pptx-parser may expose different APIs depending on version;
+    // try the most common patterns defensively.
+    let slides = [];
+    if (typeof pptxParser.parseFile === 'function') {
+      const parsed = await pptxParser.parseFile(filePath);
+      slides = parsed.slides || [];
+    } else if (typeof pptxParser === 'function') {
+      const parsed = await pptxParser(filePath);
+      slides = parsed.slides || [];
+    } else {
+      throw new Error('pptx-parser: no recognised API (parseFile or default function)');
+    }
+
+    // Build slide text — handle both {text} and {content} shapes
+    const parts = slides.map((slide, i) => {
+      const slideText =
+        (slide.text || '') ||
+        (Array.isArray(slide.content)
+          ? slide.content.map(c => c.text || c.value || '').join('\n')
+          : '');
+      return `### Slide ${i + 1}\n\n${slideText}`;
+    });
+    return { type: 'pptx', text: parts.join('\n\n'), slides: slides.length };
+  }
+
+  // Should not reach here for supported extensions
+  throw new Error(`Unsupported extension: ${ext}`);
+}
+
+// ---------------------------------------------------------------------------
+// Markdown output builders
+// ---------------------------------------------------------------------------
+
+function buildMarkdown(filePath, extraction, truncated) {
+  const lines = [];
+  lines.push(`# Extracted Source Document`);
+  lines.push('');
+  lines.push(`**Original file:** \`${filePath}\``);
+
+  if (extraction.pages != null) {
+    lines.push(`**Pages:** ${extraction.pages}`);
+  }
+  if (extraction.slides != null) {
+    lines.push(`**Slides:** ${extraction.slides}`);
+  }
+  if (truncated) {
+    lines.push(`**Note:** Content truncated to ${MAX_CHARS.toLocaleString()} characters.`);
+  }
+  lines.push('');
+  lines.push('---');
+  lines.push('');
+  lines.push(extraction.text);
+
+  return lines.join('\n');
+}
+
+function buildWarningStub(filePath, reason, suggestion) {
+  const lines = [];
+  lines.push(`# Source Document — Extraction Warning`);
+  lines.push('');
+  lines.push(`**Original file:** \`${filePath}\``);
+  lines.push(`**Status:** Could not extract content`);
+  lines.push(`**Reason:** ${reason}`);
+  if (suggestion) {
+    lines.push(`**Suggestion:** ${suggestion}`);
+  }
+  return lines.join('\n');
+}
+
+function suggestionForExtension(ext) {
+  switch (ext) {
+    case '.ppt':
+      return 'Open in PowerPoint or LibreOffice and save as .pptx or export as PDF.';
+    case '.xls':
+    case '.xlsx':
+      return 'Open in Excel or LibreOffice and export as .csv or .md.';
+    case '.odt':
+      return 'Open in LibreOffice and save as .docx or export as PDF.';
+    case '.png':
+    case '.jpg':
+    case '.jpeg':
+    case '.gif':
+    case '.bmp':
+      return 'This is an image file. Export text content as .md or .txt, or use an OCR tool to extract text.';
+    default:
+      return 'Convert to a supported format: .md, .txt, .pdf, .docx, or .pptx.';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main processing
+// ---------------------------------------------------------------------------
+
+async function processFiles(sourceDir, runDir) {
+  const outputDir = path.join(runDir, 'source-docs');
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  const files = discoverFiles(sourceDir);
+  const successPaths = [];
+  const report = [];
+
+  for (const { fullPath, relPath } of files) {
+    const ext = path.extname(fullPath).toLowerCase();
+    const baseName = path.basename(fullPath, ext);
+    // Sanitise for use as a filename
+    const safeName = relPath.replace(/[/\\]/g, '--').replace(/[^a-zA-Z0-9._-]/g, '_');
+    const outFile = path.join(outputDir, `${safeName}.md`);
+
+    if (!SUPPORTED_EXTENSIONS.has(ext)) {
+      // Write warning stub
+      const suggestion = suggestionForExtension(ext);
+      const stub = buildWarningStub(fullPath, `Unsupported file format (${ext})`, suggestion);
+      fs.writeFileSync(outFile, stub, 'utf8');
+      report.push({ file: relPath, status: 'skipped', reason: `Unsupported format ${ext}` });
+      continue;
+    }
+
+    try {
+      const extraction = await extractText(fullPath);
+      const { text: finalText, truncated } = truncate(extraction.text, fullPath);
+      const md = buildMarkdown(fullPath, { ...extraction, text: finalText }, truncated);
+      fs.writeFileSync(outFile, md, 'utf8');
+      successPaths.push(outFile);
+      report.push({
+        file: relPath,
+        status: 'extracted',
+        truncated,
+        extra: extraction.pages != null
+          ? `${extraction.pages} pages`
+          : extraction.slides != null
+          ? `${extraction.slides} slides`
+          : undefined,
+      });
+    } catch (err) {
+      const stub = buildWarningStub(fullPath, err.message, null);
+      fs.writeFileSync(outFile, stub, 'utf8');
+      report.push({ file: relPath, status: 'warning', reason: err.message });
+    }
+  }
+
+  return { successPaths, report };
+}
+
+function printSummary(report) {
+  const extracted = report.filter(r => r.status === 'extracted');
+  const warned    = report.filter(r => r.status === 'warning');
+  const skipped   = report.filter(r => r.status === 'skipped');
+
+  console.log('\nScanning source documents...\n');
+
+  if (report.length === 0) {
+    console.log('  (no user-provided source files found)');
+  } else {
+    for (const entry of report) {
+      const icon = entry.status === 'extracted' ? '✓' : entry.status === 'warning' ? '⚠' : '–';
+      let line = `  ${icon} ${entry.file}`;
+      if (entry.status === 'extracted') {
+        if (entry.extra) line += ` (${entry.extra})`;
+        if (entry.truncated) line += ' [truncated]';
+      } else {
+        line += ` — ${entry.reason}`;
+      }
+      console.log(line);
+    }
+  }
+
+  console.log('');
+  console.log(`Source docs: ${extracted.length} extracted, ${warned.length} warnings, ${skipped.length} skipped`);
+  console.log('');
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = parseArgs(process.argv);
+
+  if (!args.sourceDir || !args.runDir) {
+    console.error('Usage: scan-source-docs.js --source-dir <path> --run-dir <path> [--output-index <path>]');
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(args.sourceDir)) {
+    // No source directory at all — nothing to do
+    console.log('\nNo deepfield/source/ directory found — skipping source doc scan.\n');
+    if (args.outputIndex) {
+      fs.writeFileSync(args.outputIndex, '[]', 'utf8');
+    }
+    return;
+  }
+
+  const { successPaths, report } = await processFiles(args.sourceDir, args.runDir);
+
+  printSummary(report);
+
+  if (args.outputIndex) {
+    fs.writeFileSync(args.outputIndex, JSON.stringify(successPaths, null, 2), 'utf8');
+  }
+}
+
+main().catch(err => {
+  console.error('scan-source-docs: fatal error:', err.message);
+  process.exit(1);
+});

--- a/plugin/skills/deepfield-iterate.md
+++ b/plugin/skills/deepfield-iterate.md
@@ -218,6 +218,32 @@ const filesToRead = [
 ]
 ```
 
+### Scan User-Provided Source Documents
+
+After building the initial `filesToRead` list, run the source-doc scanner to extract text from any user-provided documents in `deepfield/source/` (PDFs, DOCX, PPTX, plain text files — excluding `baseline/repos/` and staging directories):
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/scan-source-docs.js" \
+  --source-dir deepfield/source \
+  --run-dir    deepfield/wip/run-${nextRun} \
+  --output-index deepfield/wip/run-${nextRun}/source-docs-index.json
+```
+
+The script prints a human-readable summary of every file it found, extracted, warned about, or skipped — display this output to the user as part of the scan report.
+
+Then read the generated index and append any extracted markdown files to `filesToRead`:
+
+```javascript
+const sourceDocs = fs.existsSync(`deepfield/wip/run-${nextRun}/source-docs-index.json`)
+  ? JSON.parse(fs.readFileSync(`deepfield/wip/run-${nextRun}/source-docs-index.json`, 'utf8'))
+  : [];
+
+// sourceDocs is an array of absolute paths; append to filesToRead
+filesToRead.push(...sourceDocs);
+```
+
+If `source-docs-index.json` does not exist or is empty, continue without error — it simply means no source documents are present.
+
 ## Step 4: Deep Learning
 
 ### Inject Domain-Specific Instructions


### PR DESCRIPTION
Closes #35

## Summary

- Added `plugin/scripts/scan-source-docs.js`: discovers files in `deepfield/source/` (excluding `baseline/repos/` and staging dirs), extracts text from PDF (via `pdf-parse`), DOCX (via `mammoth`), PPTX (via `pptx-parser`), and plain-text formats, writes each as a markdown file under `deepfield/wip/run-N/source-docs/`, and emits a JSON index of successfully extracted paths
- Updated `plugin/skills/deepfield-iterate.md` Step 3 to invoke the script after hash comparison, display its summary to the user, and append extracted markdown paths to `filesToRead` before launching the learner agent
- Added `pdf-parse`, `mammoth`, `pptx-parser` to `plugin/package.json` dependencies

## Behaviour

- Files in `deepfield/source/source-doc/` (and any non-excluded subdirectory) are now detected and read every learning cycle
- Unsupported formats (e.g. `.ppt`, images) produce a warning stub with conversion suggestions; extraction failures are caught per-file and do not abort the cycle
- Content is truncated to 50 000 characters per file to avoid overwhelming the agent context window
- When no source docs are present the skill continues unchanged

## Test plan

- [ ] Place a PDF with a text layer in `deepfield/source/source-doc/` and run `/df-iterate`; verify findings reference the PDF content
- [ ] Place a PPTX in `deepfield/source/source-doc/` and confirm per-slide text appears in the learner agent input
- [ ] Place a `.xls` file and confirm a warning stub is created and the cycle completes
- [ ] Run with an empty `deepfield/source/` directory and confirm no error occurs
- [ ] Verify `baseline/repos/` files are not double-counted in `filesToRead`

🤖 Generated with [Claude Code](https://claude.com/claude-code)