### PR TITLE
feat: parallel-work skill improvements

### DIFF
--- a/.claude/skills/parallel-work/SKILL.md
+++ b/.claude/skills/parallel-work/SKILL.md
@@ -123,6 +123,10 @@ For each draft PR, review:
 
 6. **Once the user gives the go-ahead:**
    - Comment on each approved PR: `"Spec approved — proceeding to implementation."`
+   - Update each draft PR title to remove the `[SPEC REVIEW]` prefix:
+     ```bash
+     gh pr edit <N> --title "<original title without [SPEC REVIEW] prefix>"
+     ```
 
 Do not proceed to Phase 4 until the user gives the go-ahead.
 


### PR DESCRIPTION
## Summary

Follow-up improvements to the `/parallel-work` skill after PR #43 was merged:

- Phase 3: Orchestrator reviews specs, then asks human before proceeding to implementation
- Phase 4: Asks human confirmation before launching implementation agents
- Phase 5: Human review gate before merging — waits for GitHub approval or Claude Code signal
- Phase 3 (post-approval): Agents update PR title by stripping `[SPEC REVIEW]` prefix

## Test plan
- [ ] Verify Phase 3 pauses and asks user before Phase 4
- [ ] Verify Phase 5 pauses and asks user before merging
- [ ] Verify PR title is updated after spec approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)