### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepfield",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "CLI tool for AI-driven knowledge base building",
   "main": "dist/cli.js",
   "bin": {

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deepfield",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "AI-driven knowledge base builder for understanding brownfield projects. Provides commands for initializing and managing deepfield/ knowledge base structure.",
   "author": {
     "name": "Deepfield Contributors",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,10 +1,10 @@
 {
   "name": "deepfield-plugin",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Claude Code plugin for Deepfield knowledge base builder",
   "private": true,
   "peerDependencies": {
-    "deepfield": "^0.2.0"
+    "deepfield": "^0.3.0"
   },
   "dependencies": {
     "mammoth": "^1.8.0",


### PR DESCRIPTION
Bumps all three version locations from 0.2.0 → 0.3.0 using the new `scripts/bump-version.sh`.

## Changes
- `cli/package.json` → `0.3.0`
- `plugin/package.json` → `0.3.0` + `peerDependencies.deepfield: ^0.3.0`
- `plugin/.claude-plugin/plugin.json` → `0.3.0`

## What's in 0.3.0
- Evidence-based confidence scoring (#49)
- Draft document readability — README index, domain READMEs, run review guides (#50)
- Legacy version 1.0.0 upgrade fix (#52)
- Repo mapping config + clone-repos command spec (#54)
- Version upgrade workflow — bump-version.sh, check-versions.sh, deepfield version command, CI check (#56)