### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepfield",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "CLI tool for AI-driven knowledge base building",
   "main": "dist/cli.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepfield",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "AI-driven knowledge base builder for understanding brownfield projects",
   "private": true,
   "workspaces": [

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deepfield",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "AI-driven knowledge base builder for understanding brownfield projects. Provides commands for initializing and managing deepfield/ knowledge base structure.",
   "author": {
     "name": "Deepfield Contributors",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,10 +1,10 @@
 {
   "name": "deepfield-plugin",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Claude Code plugin for Deepfield knowledge base builder",
   "private": true,
   "peerDependencies": {
-    "deepfield": "^0.3.0"
+    "deepfield": "^0.4.0"
   },
   "dependencies": {
     "mammoth": "^1.8.0",


### PR DESCRIPTION
Bumps all four version locations from 0.3.0 → 0.4.0.

## What's in 0.4.0
- Parallel domain learning as default after Run 0 — `--sequential` opt-out (#59, #60)
- Agent tool pattern for true parallel execution (`run_in_background: true`)
- Version upgrade workflow — bump-version.sh, check-versions.sh, CI check (#55, #56)
- Repo mapping config + clone-repos command spec (#53, #54)