### PR TITLE
fix: respect DEEPFIELD.md config in learning skills and agents

### DIFF
--- a/plugin/agents/deepfield-knowledge-synth.md
+++ b/plugin/agents/deepfield-knowledge-synth.md
@@ -16,6 +16,15 @@ You will receive:
 - **Unknowns document** (`deepfield/drafts/cross-cutting/unknowns.md`)
 - **Changelog** (`deepfield/drafts/_changelog.md`)
 - **Confidence changes** (from learning plan updates)
+- **output_language** (optional) — the language to use for all written documentation. Defaults to English if not provided.
+
+# Output Language
+
+If `output_language` is provided and is not "English", write all draft document content in that language. If the language is bilingual (e.g., "English + Zh-TW"), write English first then the second language below each section.
+
+If technical terms (function names, file paths, API names) have no equivalent in the target language, keep them in English with a parenthetical explanation in the target language.
+
+If `output_language` is absent or "English", write in English (default). Do not change the language of existing content in drafts you update — only new content you add should follow the configured language.
 
 # Synthesis Tasks
 

--- a/plugin/agents/deepfield-learner.md
+++ b/plugin/agents/deepfield-learner.md
@@ -16,6 +16,32 @@ You will receive:
 - **Domain context** (previous findings and notes for these domains)
 - **Current drafts** (existing documentation to build upon)
 - **Open questions** (from learning plan to guide exploration)
+- **output_language** (optional) — the language to use for all written documentation. Defaults to English if not provided.
+- **domain_instructions** (optional) — a map of domain name → special instructions from `DEEPFIELD.md`. If a focus topic has an entry here, apply those instructions when analyzing that domain.
+
+# Language and Domain Instructions
+
+## Output Language
+
+If `output_language` is provided and is not "English", write all documentation output (findings, drafts, summaries) in that language. If the language is bilingual (e.g., "English + Zh-TW"), write English first then the second language below each section.
+
+If technical terms have no equivalent in the target language, keep the English term and add a parenthetical explanation in the target language.
+
+If `output_language` is absent or "English", write in English (default).
+
+## Domain-Specific Instructions
+
+If `domain_instructions` contains an entry for a focus topic, include that context when analyzing files for that domain. The instructions describe known quirks, non-standard patterns, or specific focus areas the user wants emphasized.
+
+Format when applying domain instructions:
+
+```markdown
+## Domain-Specific Instructions (from DEEPFIELD.md)
+
+<instructions text>
+```
+
+If no instructions exist for a domain, omit this section for that domain.
 
 # Learning Tasks
 

--- a/plugin/skills/deepfield-iterate.md
+++ b/plugin/skills/deepfield-iterate.md
@@ -426,6 +426,10 @@ Split domains into batches of `maxAgents`. For each batch:
    ## Open questions for this domain
    ${domain.openQuestions.map(q => `- ${q}`).join('\n') || '(none)'}
 
+   ${deepfieldConfig.domainInstructions[domain.name] ? `## Domain-Specific Instructions (from DEEPFIELD.md)\n\n${deepfieldConfig.domainInstructions[domain.name]}` : ''}
+
+   ${deepfieldConfig.language && deepfieldConfig.language !== 'English' ? `## Output Language\n\nWrite all documentation in ${deepfieldConfig.language}.\nIf technical terms have no ${deepfieldConfig.language} equivalent, keep the English term with a ${deepfieldConfig.language} explanation in parentheses.` : ''}
+
    ## Output (write these files)
    - Findings: ${domain.findingsOutputPath}
    - Unknowns: ${domain.unknownsOutputPath}
@@ -559,7 +563,8 @@ Input: {
   "findings": "deepfield/wip/run-${nextRun}/findings.md",
   "existing_drafts": "deepfield/drafts/domains/*.md",
   "unknowns": "deepfield/drafts/cross-cutting/unknowns.md",
-  "changelog": "deepfield/drafts/_changelog.md"
+  "changelog": "deepfield/drafts/_changelog.md",
+  "output_language": deepfieldConfig.language
 }
 ```
 


### PR DESCRIPTION
## Summary

- `deepfield-learner` agent now accepts `output_language` and `domain_instructions` inputs, applying configured language and per-domain DEEPFIELD.md instructions during sequential learning runs
- `deepfield-knowledge-synth` agent now accepts `output_language` so all synthesized draft documents are written in the configured language
- `deepfield-iterate` skill passes `output_language` to the knowledge synthesizer invocation, and injects both language instructions and domain-specific instructions into the parallel-mode inline domain-learner prompts

Previously `DEEPFIELD.md` was scaffolded but silently ignored: language settings, domain focus, and domain-specific instructions had no effect on any agent that generates text.

Fixes #62

## Test plan

- [ ] Verify `parse-deepfield-config.js` correctly parses a DEEPFIELD.md with non-English language and domain instructions
- [ ] Verify `deepfield-iterate` sequential mode: check that learner agent is invoked with `output_language` and `domain_instructions` in its input
- [ ] Verify `deepfield-iterate` parallel mode: check that the inline prompt template includes the `## Output Language` and `## Domain-Specific Instructions` sections when configured
- [ ] Verify `deepfield-knowledge-synth` invocation includes `output_language` from `deepfieldConfig.language`
- [ ] Verify defaults: if DEEPFIELD.md is absent, all agents receive English and no domain instructions (no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)