### PR TITLE
chore: bump version to 0.4.1

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepfield",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "CLI tool for AI-driven knowledge base building",
   "main": "dist/cli.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepfield",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "AI-driven knowledge base builder for understanding brownfield projects",
   "private": true,
   "workspaces": [

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deepfield",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "AI-driven knowledge base builder for understanding brownfield projects. Provides commands for initializing and managing deepfield/ knowledge base structure.",
   "author": {
     "name": "Deepfield Contributors",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,10 +1,10 @@
 {
   "name": "deepfield-plugin",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Claude Code plugin for Deepfield knowledge base builder",
   "private": true,
   "peerDependencies": {
-    "deepfield": "^0.4.1"
+    "deepfield": "^0.4.2"
   },
   "dependencies": {
     "mammoth": "^1.8.0",


### PR DESCRIPTION
Patch bump 0.4.0 → 0.4.1.

## Fixes in 0.4.1
- Fix parallel domain learning using wrong tool — `Task` + `subagent_type` (#64, #65)
- DEEPFIELD.md language/domain config now respected by all learning agents (#62, #63)