### PR TITLE
fix: use lowercase slug names for agents, fix subagent_type in parallel mode

### DIFF
--- a/plugin/agents/deepfield-classifier.md
+++ b/plugin/agents/deepfield-classifier.md
@@ -1,5 +1,5 @@
 ---
-name: Deepfield Classifier
+name: deepfield-classifier
 description: Classify sources by type, trust level, and domain relevance
 color: blue
 ---

--- a/plugin/agents/deepfield-domain-detector.md
+++ b/plugin/agents/deepfield-domain-detector.md
@@ -1,5 +1,5 @@
 ---
-name: Deepfield Domain Detector
+name: deepfield-domain-detector
 description: Auto-detect project domains from structure and content patterns
 color: purple
 ---

--- a/plugin/agents/deepfield-domain-learner.md
+++ b/plugin/agents/deepfield-domain-learner.md
@@ -1,5 +1,5 @@
 ---
-name: Deepfield Domain Learner
+name: deepfield-domain-learner
 description: Focused single-domain learning specialist — analyzes one domain's files in isolation and writes findings and unknowns to domain-scoped output files
 color: blue
 ---

--- a/plugin/agents/deepfield-knowledge-synth.md
+++ b/plugin/agents/deepfield-knowledge-synth.md
@@ -1,5 +1,5 @@
 ---
-name: Deepfield Knowledge Synthesizer
+name: deepfield-knowledge-synth
 description: Transform findings into natural prose documentation, maintain drafts, track changes
 color: orange
 ---

--- a/plugin/agents/deepfield-learner.md
+++ b/plugin/agents/deepfield-learner.md
@@ -1,5 +1,5 @@
 ---
-name: Deepfield Learner
+name: deepfield-learner
 description: Deep reading specialist - connects concepts, identifies patterns, discovers relationships
 color: yellow
 ---

--- a/plugin/agents/deepfield-plan-generator.md
+++ b/plugin/agents/deepfield-plan-generator.md
@@ -1,5 +1,5 @@
 ---
-name: Deepfield Plan Generator
+name: deepfield-plan-generator
 description: Generate and maintain learning plans with topics, priorities, and confidence tracking
 color: green
 ---

--- a/plugin/agents/deepfield-scanner.md
+++ b/plugin/agents/deepfield-scanner.md
@@ -1,5 +1,5 @@
 ---
-name: Deepfield Scanner
+name: deepfield-scanner
 description: Shallow structural scan to map project without deep reading
 color: cyan
 ---

--- a/plugin/agents/deepfield-term-extractor.md
+++ b/plugin/agents/deepfield-term-extractor.md
@@ -1,5 +1,5 @@
 ---
-name: Deepfield Term Extractor
+name: deepfield-term-extractor
 description: Terminology extraction specialist - detects domain terms, acronyms, and definitions from source files and documentation
 color: cyan
 ---

--- a/plugin/skills/deepfield-iterate.md
+++ b/plugin/skills/deepfield-iterate.md
@@ -407,7 +407,7 @@ Split domains into batches of `maxAgents`. For each batch:
 2. **Launch all agents for this batch in a single message** (one tool call block with multiple Task invocations) with `run_in_background: true`. This ensures true parallelism — all agents in the batch are submitted concurrently in one round-trip.
 
    For each domain in the batch, invoke the **Task tool** with the following parameters:
-   - **subagent_type**: `"deepfield:Deepfield Domain Learner"`
+   - **subagent_type**: `"deepfield-domain-learner"`
    - **description**: `"Learn ${domain.name} domain (Run ${runNumber})"`
    - **run_in_background**: `true`
    - **prompt**: the inline prompt below (fill in all placeholders from the `agentTasks` prepared in step 4b)
@@ -457,9 +457,9 @@ Split domains into batches of `maxAgents`. For each batch:
    **You MUST make all Task tool calls for this batch in a SINGLE message** (one `<function_calls>` block with one Task call per domain). Do NOT launch agents one at a time in separate messages — that is sequential, not parallel.
 
    Example for a batch with 3 domains (auth, api, database):
-   - First Task call: `subagent_type="deepfield:Deepfield Domain Learner"`, `description="Learn auth domain (Run N)"`, `run_in_background=true`, prompt filled with auth context
-   - Second Task call: `subagent_type="deepfield:Deepfield Domain Learner"`, `description="Learn api domain (Run N)"`, `run_in_background=true`, prompt filled with api context
-   - Third Task call: `subagent_type="deepfield:Deepfield Domain Learner"`, `description="Learn database domain (Run N)"`, `run_in_background=true`, prompt filled with database context
+   - First Task call: `subagent_type="deepfield-domain-learner"`, `description="Learn auth domain (Run N)"`, `run_in_background=true`, prompt filled with auth context
+   - Second Task call: `subagent_type="deepfield-domain-learner"`, `description="Learn api domain (Run N)"`, `run_in_background=true`, prompt filled with api context
+   - Third Task call: `subagent_type="deepfield-domain-learner"`, `description="Learn database domain (Run N)"`, `run_in_background=true`, prompt filled with database context
 
    All three calls in the same message. Wait for all to complete before proceeding.
 


### PR DESCRIPTION
Fixes parallel domain learning still falling back to sequential agent.

## Root cause (confirmed from official docs)
The Claude Code docs state agent `name:` frontmatter must use **"lowercase letters and hyphens"**. All deepfield agents used display names like `"Deepfield Domain Learner"` (spaces + caps).

The `subagent_type: "deepfield:Deepfield Domain Learner"` in the iterate skill was therefore invalid — no matching agent could be found — so Claude fell back to the generic sequential learner.

## Fix
- All 8 agent `name:` fields renamed to lowercase slugs matching their filenames
- `subagent_type` updated to `"deepfield-domain-learner"` (the correct slug)

## Reference
https://code.claude.com/docs/en/sub-agents — "Unique identifier using lowercase letters and hyphens"