### PR TITLE
fix: use npm install instead of npm ci in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install CLI dependencies
         working-directory: cli
-        run: npm ci
+        run: npm install
 
       - name: Set version in all package files
         run: |


### PR DESCRIPTION
No package-lock.json in repo — npm ci requires one. Switch to npm install.