### PR TITLE
fix: revert marketplace plugin source to relative path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,12 +9,7 @@
   "plugins": [
     {
       "name": "deepfield",
-      "source": {
-        "source": "git-subdir",
-        "url": "https://github.com/TomazWang/deepfield.git",
-        "path": "plugin",
-        "ref": "latest"
-      },
+      "source": "./plugin",
       "description": "Iteratively learns your codebase and distills institutional knowledge",
       "author": {
         "name": "TomazWang"


### PR DESCRIPTION
git-subdir source type fails schema validation. Relative path ./plugin worked before and is correct for a GitHub-hosted marketplace (Claude Code clones the full repo).