### PR TITLE
feat(#96,#97): CLI scaffold for 3-tier structure + document templates

### DIFF
--- a/cli/src/commands/upgrade-helpers.ts
+++ b/cli/src/commands/upgrade-helpers.ts
@@ -231,7 +231,7 @@ export function createValidateCommand(): Command {
  */
 export function createScaffoldCrossCuttingCommand(): Command {
   return new Command('upgrade:scaffold-cross-cutting')
-    .description('Check and create missing cross-cutting files (terminology.md, unknowns.md) from templates')
+    .description('Check and create missing cross-cutting files (glossary.md, unknowns.md) from templates')
     .option('--deepfield-dir <path>', 'Path to deepfield workspace directory', './deepfield')
     .option('--templates-dir <path>', 'Path to plugin templates directory')
     .action((options) => {
@@ -245,7 +245,7 @@ export function createScaffoldCrossCuttingCommand(): Command {
           ? require('path').resolve(cwd, options.templatesDir)
           : join(dirname(dirname(__filename)), 'plugin', 'templates');
 
-        const filesToScaffold = ['terminology.md', 'unknowns.md'];
+        const filesToScaffold = ['glossary.md', 'unknowns.md'];
 
         // Ensure cross-cutting directory exists
         mkdirSync(crossCuttingDir, { recursive: true });

--- a/cli/src/core/scaffold.ts
+++ b/cli/src/core/scaffold.ts
@@ -104,6 +104,10 @@ export async function scaffold(
     'deepfield/drafts/behavior',
     'deepfield/drafts/tech',
     'deepfield/drafts/cross-cutting',
+    'deepfield/drafts/en/product-spec',
+    'deepfield/drafts/en/tech-spec',
+    'deepfield/drafts/en/feature-spec',
+    'deepfield/drafts/archive/feature-spec',
     'deepfield/output',
   ];
 

--- a/cli/templates/cross-cutting/concerns-registry.md
+++ b/cli/templates/cross-cutting/concerns-registry.md
@@ -1,0 +1,4 @@
+# Cross-Cutting Concerns Registry
+
+| Concern | Type | Tech Design | Implementation |
+|---|---|---|---|

--- a/cli/templates/glossary.md
+++ b/cli/templates/glossary.md
@@ -1,0 +1,4 @@
+# Glossary
+
+| Term | Definition | zh-tw | Domain |
+|---|---|---|---|

--- a/plugin/templates/feature-spec-design.md
+++ b/plugin/templates/feature-spec-design.md
@@ -1,0 +1,17 @@
+# {Feature Name} — Design
+
+## Changes to Product Spec
+What changes in user-facing behavior.
+
+## Changes to Tech Spec
+What architectural or implementation changes are required.
+
+## Migration / Rollout
+How existing data or users are affected.
+
+## Open Questions
+Unresolved design decisions blocking implementation.
+
+## See Also
+- Feature overview: [./index.md]
+- Feature status: [./status.md]

--- a/plugin/templates/feature-spec-index.md
+++ b/plugin/templates/feature-spec-index.md
@@ -1,0 +1,18 @@
+# {Feature Name}
+
+## Goal
+What we are trying to achieve. One paragraph.
+
+## Scope
+What is included. What is explicitly excluded.
+
+## Acceptance Criteria
+Observable outcomes that define delivery completion.
+
+## Affected Domains
+- product-spec: [{domain}](../../product-spec/{domain}/index.md)
+- tech-spec: [{domain}](../../tech-spec/{domain}/design.md)
+
+## Timeline
+- Kickoff: YYYY-MM-DD
+- Target delivery: YYYY-MM-DD

--- a/plugin/templates/feature-spec-status.md
+++ b/plugin/templates/feature-spec-status.md
@@ -1,0 +1,13 @@
+# {Feature Name} — Status
+
+## Current Status
+`in-progress` | `delivered` | `cancelled`
+
+## Decisions Made
+Decisions taken during delivery that differ from the original design.
+
+## Known Deviations
+Where implementation diverged from feature-spec/design.md and why.
+
+## Delivered
+YYYY-MM-DD

--- a/plugin/templates/product-spec-index.md
+++ b/plugin/templates/product-spec-index.md
@@ -1,0 +1,20 @@
+# {Domain Name}
+
+## Purpose
+What problem this solves for users. No technical jargon.
+
+## Stakeholder Goals
+What stakeholders expect this domain to deliver.
+
+## User Scenarios
+- As a [user type], I can [action] so that [outcome]
+
+## Acceptance Criteria
+Observable outcomes that define success for this domain.
+
+## Out of Scope
+What this domain explicitly does not cover.
+
+## See Also
+- Technical design: [../../tech-spec/{domain}/design.md]
+- Glossary: [../../../glossary.md]

--- a/plugin/templates/tech-spec-contract.md
+++ b/plugin/templates/tech-spec-contract.md
@@ -1,0 +1,21 @@
+<!-- Language-agnostic: do not create zh-tw variant for this file.
+     API terms, function signatures, and endpoint paths are universal. -->
+
+# {Domain Name} — {Contract Name} Contract
+
+## REST API
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+
+### Request / Response Shapes
+
+## Function Interfaces
+
+## Events / Messages
+
+| Event | Payload | When |
+|---|---|---|
+
+## Actual vs Intended
+Where implementation diverges from design intent.

--- a/plugin/templates/tech-spec-decisions.md
+++ b/plugin/templates/tech-spec-decisions.md
@@ -1,0 +1,13 @@
+<!-- APPEND-ONLY: Never rewrite or remove existing records.
+     To supersede: add a new ADR and update the old entry's Status field. -->
+
+# {Domain Name} — Decisions
+
+## ADR-001: {Decision Title}
+
+- **Status**: `proposed` | `current` | `superseded by ADR-NNN`
+- **Date**: YYYY-MM-DD
+- **Context**: Why this decision was needed.
+- **Decision**: What was chosen.
+- **Alternatives considered**: What was rejected and why.
+- **Consequences**: Trade-offs accepted.

--- a/plugin/templates/tech-spec-design.md
+++ b/plugin/templates/tech-spec-design.md
@@ -1,0 +1,20 @@
+# {Domain Name} — Design
+
+## Summary
+One paragraph. Role in the system. Key technical constraints.
+
+## Architecture
+Component structure, service boundaries, data flows.
+Mermaid diagrams encouraged.
+
+## Data Flow
+How data enters, transforms, and exits this domain.
+
+## Risks & Technical Debt
+| Expected | Actual | Reason |
+|---|---|---|
+
+## See Also
+- Product context: [../../product-spec/{domain}/index.md]
+- Decisions: [./decisions.md]
+- Implementation: [./implementation.md]

--- a/plugin/templates/tech-spec-impl-component.md
+++ b/plugin/templates/tech-spec-impl-component.md
@@ -1,0 +1,17 @@
+# {Component or Platform Name}
+
+## Overview
+What this component does. Entry point in the codebase.
+
+## Internal Design
+Key algorithms, patterns, design choices specific to this component.
+
+## Data Models
+Structs, schemas. For complex schemas → see db-schema.md
+
+## Error Handling
+How failures are handled and surfaced.
+
+## See Also
+- Component map: [./implementation.md]
+- Design: [./design.md]

--- a/plugin/templates/tech-spec-implementation.md
+++ b/plugin/templates/tech-spec-implementation.md
@@ -1,0 +1,16 @@
+# {Domain Name} — Implementation
+
+## Component Map
+| Component | Responsibility | File/path |
+|---|---|---|
+
+## Shared Patterns
+Common patterns used across components in this domain.
+
+## Dependencies
+- **Calls**: external services or domains this depends on
+- **Called by**: what depends on this domain
+
+## See Also
+- Design: [./design.md]
+- Component details: impl-*.md files in this folder


### PR DESCRIPTION
Closes #96, closes #97

## Summary

### Phase 1 — CLI scaffold (#96)
- `cli/src/core/scaffold.ts` — adds `en/product-spec`, `en/tech-spec`, `en/feature-spec`, `archive/feature-spec` to `directories` array; keeps existing `behavior/` and `tech/` dirs (Phase 6 handles removal)
- `cli/src/commands/upgrade-helpers.ts` — replaces `terminology.md` with `glossary.md` in `upgrade:scaffold-cross-cutting`
- `cli/templates/glossary.md` — table-format seed (`| Term | Definition | zh-tw | Domain |`)
- `cli/templates/cross-cutting/concerns-registry.md` — table-format seed

### Phase 2 — Document templates (#97)
Nine new templates in `plugin/templates/`:
- `product-spec-index.md` — stakeholder view
- `feature-spec-{index,design,status}.md` — time-bounded feature lifecycle
- `tech-spec-design.md` — L2 architecture + risks
- `tech-spec-decisions.md` — ADR log (`<!-- APPEND-ONLY -->`, canonical `## ADR-001:` format)
- `tech-spec-implementation.md` — L3 component map
- `tech-spec-contract.md` — API/function interfaces (`<!-- Language-agnostic -->`)
- `tech-spec-impl-component.md` — per-component/platform detail

## Review requested
@robodev.claude-vm165 please review — particularly the `directories` array placement in `scaffold.ts` and the ADR canonical format in `tech-spec-decisions.md`.

---
👾 @robodev.claude-M4DN