### PR TITLE
feat(#99): deepfield-translator agent + /df-translate command

### DIFF
--- a/plugin/agents/deepfield-translator.md
+++ b/plugin/agents/deepfield-translator.md
@@ -119,13 +119,11 @@ After successfully writing each translated file (not stubs), update the domain m
 
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/scripts/update-domain-manifest.js" \
-  --workspace "${workspace_root}" \
-  --domain "${source_domain}" \
-  --spec "${source_spec}" \
-  --add-language "${target_language}"
+  "${workspace_root}/wip/domain-manifest.json" \
+  "{\"slug\":\"${source_domain}\",\"languages\":[\"${target_language}\"]}"
 ```
 
-This adds `target_language` to the `languages` array for the domain entry in `wip/domain-manifest.json` if not already present.
+The script performs an additive merge on `languages` — `target_language` is unioned with existing values, so existing languages are never removed.
 
 **If the script is missing:** Log a warning (`update-domain-manifest.js not found — manifest not updated`) and continue. Do not abort the translation run.
 

--- a/plugin/commands/df-translate.md
+++ b/plugin/commands/df-translate.md
@@ -138,7 +138,7 @@ Input: {
   "source_domain":   "<domain | null>",
   "source_file":     "<file | null>",
   "stub_mode":       <true | false>,
-  "workspace_root":  "./deepfield"
+  "workspace_root":  "<absolute path — resolve via: realpath ./deepfield>"
 }
 ```
 


### PR DESCRIPTION
## Summary

- Adds `plugin/agents/deepfield-translator.md` — translation specialist agent that reads `drafts/en/{spec}/{domain}/`, writes `drafts/{lang}/{spec}/{domain}/`, skips `contract-*.md` files, supports `--stub` mode for deferred translation, and calls `update-domain-manifest.js` to record rendered languages in `wip/domain-manifest.json`.
- Adds `plugin/commands/df-translate.md` — user-facing `/df-translate` command supporting single-domain, single-spec-tier, full, and `--all` (stub sweep) modes with `--lang`, `--spec`, `--stub` flags, full state validation, and a structured post-run report.
- Closes #99 (Phase 4).

## Test plan

- [ ] Run `/df-translate auth --spec product-spec` — verify translated files appear under `drafts/zh-tw/product-spec/auth/` and `contract-*.md` files are skipped.
- [ ] Run `/df-translate --stub` — verify `<!-- needs-translation -->` stubs are written for all non-contract files.
- [ ] Run `/df-translate --all` — verify only stub files are picked up and translated.
- [ ] Run `/df-translate` with no `drafts/en/` directory — verify prerequisite error message.
- [ ] Run `/df-translate nonexistent-domain` — verify domain-not-found error with available domain list.
- [ ] Confirm `wip/domain-manifest.json` gets `"zh-tw"` appended to the domain's `languages` array after a successful run.
- [ ] Confirm behaviour when `update-domain-manifest.js` is absent: warning logged, translation continues.

👾 @robodev.claude-vm165