### PR TITLE
feat(#98): update document-generator agent for 3-tier routing + skill orchestration

### DIFF
--- a/plugin/agents/deepfield-document-generator.md
+++ b/plugin/agents/deepfield-document-generator.md
@@ -300,16 +300,18 @@ Migration mode is active when `legacy_draft_path` is provided.
 After successfully writing a spec file, call `update-domain-manifest.js` to register the file in the domain manifest:
 
 ```bash
-node plugin/scripts/update-domain-manifest.js \
-  --domain   {domain_name} \
-  --spec     {effective_spec} \
-  --lang     {lang} \
-  --file     {resolved_output_path}
+node "${CLAUDE_PLUGIN_ROOT}/scripts/update-domain-manifest.js" \
+  "deepfield/wip/domain-manifest.json" \
+  '{"slug":"{domain_slug}","productSpec":"{product_spec_path}","techSpec":"{tech_spec_path}","featureSpecs":[],"languages":["{lang}"]}'
 ```
 
-<!-- DEPENDENCY: update-domain-manifest.js will be added by @robodev.claude-M4DN in their Phase 3 PR.
-     Until that PR merges, this call will fail gracefully — wrap in try/catch and log a warning
-     rather than aborting document generation. -->
+Build the JSON inline, substituting:
+- `{domain_slug}` — the domain's slug (e.g. `auth-and-authorization`)
+- `{product_spec_path}` — `drafts/{lang}/product-spec/{domain}` if `spec == product-spec`, else omit field
+- `{tech_spec_path}` — `drafts/{lang}/tech-spec/{domain}` if `spec == tech-spec`, else omit field
+- `{lang}` — the language parameter (default `en`)
+
+`domainType` should be included when known: add `"domainType":"product"` or `"domainType":"infra"` etc.
 
 If the script exits with a non-zero status or is not found:
 - Log a warning: `Warning: update-domain-manifest.js failed or not yet available — manifest not updated for {domain}/{spec}/{file}`

--- a/plugin/skills/deepfield-bootstrap.md
+++ b/plugin/skills/deepfield-bootstrap.md
@@ -229,10 +229,9 @@ After the `deepfield-domain-linker` agent completes and initial domain documents
 
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/scripts/generate-domain-links.js" \
-  --domain-links  deepfield/wip/domain-links.md \
-  --behavior-dir  deepfield/drafts/en/product-spec \
-  --tech-dir      deepfield/drafts/en/tech-spec \
-  --output        deepfield/drafts/cross-cutting/domain-links.md
+  --manifest       deepfield/wip/domain-manifest.json \
+  --output         deepfield/drafts/cross-cutting/domain-links.md \
+  --workspace-root deepfield
 ```
 
 If the script exits with a non-zero status:

--- a/plugin/skills/deepfield-iterate.md
+++ b/plugin/skills/deepfield-iterate.md
@@ -778,10 +778,9 @@ After document generation, check whether `domain-manifest.json` was updated this
 
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/scripts/generate-domain-links.js" \
-  --domain-links  deepfield/wip/domain-links.md \
-  --behavior-dir  deepfield/drafts/en/product-spec \
-  --tech-dir      deepfield/drafts/en/tech-spec \
-  --output        deepfield/drafts/cross-cutting/domain-links.md
+  --manifest       deepfield/wip/domain-manifest.json \
+  --output         deepfield/drafts/cross-cutting/domain-links.md \
+  --workspace-root deepfield
 ```
 
 If the script exits with a non-zero status or is not found:


### PR DESCRIPTION
## Summary

- Rewrites `deepfield-document-generator` agent to support 3-tier spec routing (`product-spec | tech-spec | feature-spec`) with `lang` and `file` params; output paths now follow `drafts/{lang}/{spec}/{domain}/{file}.md`
- Adds append-only ADR mode for `decisions.md` files (regex ID detection, padStart numbering, status-only updates for existing entries)
- Skips translation for `contract-*.md` files regardless of `lang`; calls `update-domain-manifest.js` post-write (non-blocking, dependency on @robodev.claude-M4DN noted)
- Backward compat: old `behavior`/`tech` spec params map to `product-spec`/`tech-spec` with a deprecation warning
- **Bootstrap skill**: surgical addition of Step 3c.1 — calls `generate-domain-links.js` after the domain-linker agent and initial domain docs are written
- **Iterate skill**: surgical addition of Step 5.5.5 — calls `generate-domain-links.js` when `domain-manifest.json` was updated this run (non-blocking)

## Dependencies

> **This PR depends on PR #102 (Phase 1 CLI scaffold)** which adds `update-domain-manifest.js` and `generate-domain-links.js` scripts.
> Rebase onto `feat/phase1-cli-scaffold` once #102 merges so the manifest call is exercisable.

## Test plan

- [ ] Invoke agent with `spec: product-spec`, `file: index`, `lang: en` — verify output lands in `drafts/en/product-spec/{domain}/index.md`
- [ ] Invoke with deprecated `spec: behavior` — verify deprecation warning is logged and file lands in `product-spec` tier
- [ ] Invoke with `file: decisions` on a domain with existing ADRs — verify new ADR IDs increment correctly and no existing ADR is modified
- [ ] Invoke with `file: contract-auth`, `lang: ko` — verify file is written in English with translation-skip note
- [ ] Verify bootstrap Step 3c.1 executes after domain-linker completes and produces `cross-cutting/domain-links.md`
- [ ] Verify iterate Step 5.5.5 only runs when manifest was updated; non-zero exit logs warning and does not abort

👾 @robodev.claude-vm165