### PR TITLE
feat(#98): DomainManifestSchema + update-domain-manifest + generate-domain-links

### DIFF
--- a/cli/src/core/schemas.ts
+++ b/cli/src/core/schemas.ts
@@ -108,6 +108,23 @@ export const DomainEntrySchema = z.object({
   slug: z.string().min(1),
 
   /**
+   * Human-readable display name for this domain.
+   * Used as the heading in domain-links.md and other rendered output.
+   * e.g. "Auth and Authorization"
+   * Falls back to slug when absent.
+   */
+  displayName: z.string().optional(),
+
+  /**
+   * Domain classification for filtering and rendering.
+   * - "product"       — user-facing product domains (features, flows)
+   * - "tech"          — engineering / implementation domains
+   * - "infra"         — infrastructure, deployment, platform
+   * - "cross-cutting" — concerns that span multiple domains
+   */
+  domainType: z.enum(['product', 'tech', 'infra', 'cross-cutting']).optional(),
+
+  /**
    * Path to the product-spec folder for this domain.
    * Relative to the workspace root (deepfield/).
    * e.g. "drafts/en/product-spec/auth-and-authorization"

--- a/plugin/scripts/generate-domain-links.js
+++ b/plugin/scripts/generate-domain-links.js
@@ -129,8 +129,17 @@ function generateMarkdown(manifest, workspaceRoot) {
   }
 
   for (const domain of domains) {
-    lines.push(`## ${domain.slug}`);
+    // Use displayName for a human-readable heading; fall back to slug for
+    // backward compat with manifests written before displayName was added.
+    const heading = domain.displayName || domain.slug;
+    lines.push(`## ${heading}`);
     lines.push('');
+
+    // Show domain type badge when present (enables filtering in rendered output)
+    if (domain.domainType) {
+      lines.push(`**Type**: \`${domain.domainType}\``);
+      lines.push('');
+    }
 
     if (domain.notes) {
       lines.push(`> ${domain.notes}`);

--- a/plugin/scripts/update-domain-manifest.js
+++ b/plugin/scripts/update-domain-manifest.js
@@ -8,6 +8,8 @@
  * <domain_json> must match DomainEntry shape (see cli/src/core/schemas.ts):
  *   {
  *     "slug": "auth-and-authorization",
+ *     "displayName":  "Auth and Authorization",                          // optional
+ *     "domainType":   "product",                                         // optional: product|tech|infra|cross-cutting
  *     "productSpec": "drafts/en/product-spec/auth-and-authorization",   // optional
  *     "techSpec":    "drafts/en/tech-spec/auth-and-authorization",      // optional
  *     "featureSpecs": [],                                                // optional
@@ -17,7 +19,8 @@
  *
  * Behaviour:
  *   - If manifest does not exist, creates it with a single domain entry.
- *   - If the slug already exists, deep-merges the new fields (arrays are replaced, not appended).
+ *   - If the slug already exists, deep-merges the new fields.
+ *     Array fields (languages, featureSpecs) are merged additively (union), not replaced.
  *   - Atomic write: write to temp file then rename.
  *
  * Exit codes:
@@ -38,6 +41,7 @@ const path = require('path');
 // ---------------------------------------------------------------------------
 const DOMAIN_ENTRY_REQUIRED = ['slug'];
 const MANIFEST_REQUIRED = ['domains'];
+const DOMAIN_TYPE_VALUES = ['product', 'tech', 'infra', 'cross-cutting'];
 
 function validateDomainEntry(entry) {
   for (const field of DOMAIN_ENTRY_REQUIRED) {
@@ -48,12 +52,35 @@ function validateDomainEntry(entry) {
   if (typeof entry.slug !== 'string' || entry.slug.trim() === '') {
     throw new Error('DomainEntry.slug must be a non-empty string');
   }
+  if (entry.displayName !== undefined && typeof entry.displayName !== 'string') {
+    throw new Error('DomainEntry.displayName must be a string');
+  }
+  if (entry.domainType !== undefined && !DOMAIN_TYPE_VALUES.includes(entry.domainType)) {
+    throw new Error(`DomainEntry.domainType must be one of: ${DOMAIN_TYPE_VALUES.join(', ')}`);
+  }
   if (entry.featureSpecs !== undefined && !Array.isArray(entry.featureSpecs)) {
     throw new Error('DomainEntry.featureSpecs must be an array');
   }
   if (entry.languages !== undefined && !Array.isArray(entry.languages)) {
     throw new Error('DomainEntry.languages must be an array');
   }
+}
+
+// ---------------------------------------------------------------------------
+// Array helpers
+// ---------------------------------------------------------------------------
+/**
+ * Return a new array containing all unique elements from both arrays.
+ * Preserves insertion order (existing elements first, then new additions).
+ */
+function unionArray(existing, incoming) {
+  if (!Array.isArray(existing)) return Array.isArray(incoming) ? [...incoming] : [];
+  if (!Array.isArray(incoming)) return [...existing];
+  const result = [...existing];
+  for (const item of incoming) {
+    if (!result.includes(item)) result.push(item);
+  }
+  return result;
 }
 
 function validateManifest(manifest) {
@@ -122,8 +149,14 @@ if (fs.existsSync(manifestPath)) {
 // Upsert domain entry by slug
 const existingIndex = manifest.domains.findIndex(d => d.slug === domainEntry.slug);
 if (existingIndex >= 0) {
-  // Merge: new fields overwrite existing, but don't remove fields not mentioned
-  manifest.domains[existingIndex] = Object.assign({}, manifest.domains[existingIndex], domainEntry);
+  const existing = manifest.domains[existingIndex];
+  // Merge scalar fields: new values overwrite existing, absent fields are preserved.
+  // Array fields (languages, featureSpecs) are merged additively (union) so that
+  // passing {"slug":"x","languages":["ko"]} does NOT discard existing ["en","zh-tw"].
+  manifest.domains[existingIndex] = Object.assign({}, existing, domainEntry, {
+    languages:    unionArray(existing.languages,    domainEntry.languages),
+    featureSpecs: unionArray(existing.featureSpecs, domainEntry.featureSpecs),
+  });
 } else {
   // Apply defaults for optional arrays
   manifest.domains.push({


### PR DESCRIPTION
## Summary

Implements the `@robodev.claude-M4DN` deliverables assigned in issue #98 (Phase 3 — Manifest Schema & Links).

- **`cli/src/core/schemas.ts`** — `DomainEntrySchema` + `DomainManifestSchema` (Zod). Canonical shape for `wip/domain-manifest.json`. TypeScript consumers import this; CJS scripts use inline validation that mirrors it.
- **`plugin/scripts/update-domain-manifest.js`** — Atomically upserts a domain entry in `domain-manifest.json`. Supports create-on-first-write and deep-merge on subsequent calls. Inline validation with clear exit codes (0/1/2/3).
- **`plugin/scripts/generate-domain-links.js`** — Reads `domain-manifest.json`, generates `cross-cutting/domain-links.md` atomically. Called by `deepfield-bootstrap` (Step 3c.1) and `deepfield-iterate` (Step 5.5.5) per PR #105.

## Test plan

- [x] `update-domain-manifest.js`: create manifest, upsert new domain, merge field into existing domain
- [x] `generate-domain-links.js`: generates correct markdown with 2 domains, feature-specs, multi-language
- [x] Both scripts exit 0 on success, 2 on bad JSON, 3 on validation failure

## Dependencies

- Depends on PR #102 (scaffold directories must exist at runtime)
- PR #105 (`deepfield-document-generator`) calls `update-domain-manifest.js` — this PR is the prerequisite

---

👾 @robodev.claude-M4DN