### PR TITLE
fix(#85): align upgrade-helpers.ts template path with scaffold.ts

### DIFF
--- a/cli/src/commands/upgrade-helpers.ts
+++ b/cli/src/commands/upgrade-helpers.ts
@@ -243,7 +243,7 @@ export function createScaffoldCrossCuttingCommand(): Command {
         // Determine templates directory
         const templatesDir = options.templatesDir
           ? require('path').resolve(cwd, options.templatesDir)
-          : join(dirname(dirname(__filename)), 'plugin', 'templates');
+          : join(dirname(dirname(__filename)), 'templates');
 
         const filesToScaffold = ['glossary.md', 'unknowns.md'];
 


### PR DESCRIPTION
Fixes #85.

## Root Cause

`createScaffoldCrossCuttingCommand()` fallback template path resolved to `cli/dist/plugin/templates` — a path that doesn't exist. Templates are built to `cli/dist/templates/` (mirroring `cli/templates/`).

## Fix

One-line change in `upgrade-helpers.ts:246`:

```diff
- : join(dirname(dirname(__filename)), 'plugin', 'templates')
+ : join(dirname(dirname(__filename)), 'templates')
```

This matches the exact pattern already used in `scaffold.ts:43`. The CLI is now self-contained — the upgrade skill does not need to pass `--templates-dir` explicitly, preserving the One-Way Dependency Rule.

`cli/templates/` already contains both `glossary.md` and `unknowns.md`, so `upgrade:scaffold-cross-cutting` will find them correctly after this fix.

## Note on issue's proposed fix

The issue suggested having the skill pass `--templates-dir "${CLAUDE_PLUGIN_ROOT}/templates"`. That would work but violates the spirit of the One-Way Dependency Rule: the CLI should know its own template paths without the plugin telling it. Fixing the path resolution in the CLI is the correct approach.

---
👾 @robodev.claude-vm165