### PR TITLE
fix(#111): land marketplace fix onto main

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,12 +9,7 @@
   "plugins": [
     {
       "name": "deepfield",
-      "source": {
-        "source": "git-subdir",
-        "url": "https://github.com/TomazWang/deepfield.git",
-        "path": "plugin",
-        "ref": "latest"
-      },
+      "source": "./plugin",
       "description": "Iteratively learns your codebase and distills institutional knowledge",
       "author": {
         "name": "TomazWang"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,75 +3,68 @@ name: Release
 on:
   push:
     branches:
-      - "release/**"
+      - main
 
 jobs:
   release:
-    name: Set version and publish release
+    name: Tag and publish release
     runs-on: ubuntu-latest
     permissions:
       contents: write
 
     steps:
-      - name: Extract version from branch name
-        id: version
-        run: |
-          BRANCH="${GITHUB_REF#refs/heads/release/}"
-          echo "version=$BRANCH" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout release branch
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Install jq
         run: sudo apt-get install -y jq
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          node-version: "20"
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install CLI dependencies
-        working-directory: cli
-        run: npm install
+      - name: Read version from plugin.json
+        id: version
+        run: |
+          V=$(jq -r '.version' plugin/.claude-plugin/plugin.json)
+          echo "version=$V" >> "$GITHUB_OUTPUT"
 
-      - name: Set version in all package files
+      - name: Skip if dev version
+        id: skip
         run: |
           V="${{ steps.version.outputs.version }}"
-          set_ver() { jq "$2" "$1" > "$1.tmp" && mv "$1.tmp" "$1"; }
-          set_ver package.json                        ".version = \"$V\""
-          set_ver cli/package.json                    ".version = \"$V\""
-          set_ver plugin/package.json                 ".version = \"$V\" | .peerDependencies.deepfield = \"^$V\""
-          set_ver plugin/.claude-plugin/plugin.json   ".version = \"$V\""
+          if [ "$V" = "0.0.0-dev" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Rebuild CLI
-        working-directory: cli
-        run: npm run build
-
-      - name: Verify versions in sync
+      - name: Verify all version files are in sync
+        if: steps.skip.outputs.skip == 'false'
         run: ./scripts/check-versions.sh
 
-      - name: Commit and push
-        run: |
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json cli/package.json plugin/package.json \
-            "plugin/.claude-plugin/plugin.json"
-          git add cli/dist/ || true
-          git diff --cached --quiet || \
-            git commit -m "chore: release v${{ steps.version.outputs.version }}"
-          git push origin ${{ github.ref_name }}
-
-      - name: Tag release
+      - name: Skip if tag already exists
+        id: tag_check
+        if: steps.skip.outputs.skip == 'false'
         run: |
           V="${{ steps.version.outputs.version }}"
+          if git tag | grep -q "^v$V$"; then
+            echo "Tag v$V already exists — skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Tag release
+        if: steps.skip.outputs.skip == 'false' && steps.tag_check.outputs.skip == 'false'
+        run: |
+          V="${{ steps.version.outputs.version }}"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag "v$V"
           git push origin "v$V"
 
       - name: Move latest tag
+        if: steps.skip.outputs.skip == 'false' && steps.tag_check.outputs.skip == 'false'
         run: |
           git tag -f latest
           git push origin latest --force

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches-ignore:
       - main
-      - "release/**"
   pull_request:
     branches: [main]
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -506,33 +506,45 @@ Three layers prevent context overload:
 
 ## Release Workflow
 
-**Trunk-based, CI tag-triggered releases. Main is always `0.0.0-dev`.**
+**`main` is trunk and always the latest release. All work flows through PRs.**
 
-- Version files on main are permanently `0.0.0-dev` — never bump them
-- Real semver only lives on `release/X.Y.Z` branches and git tags
+```
+feat/* / fix/* / docs/*  →  PR  →  main   (version stays 0.0.0-dev)
+bump/X.Y.Z               →  PR  →  main   (bumps version — this IS the release)
+```
+
+- `main` — default branch; always the latest stable release; what marketplace users get
+- Feature/fix branches — normal work; version files stay `0.0.0-dev`
+- `bump/X.Y.Z` — release PR; manually bumps all 4 version files to the real version
 
 ### Cutting a release
 
 ```bash
+# 1. Create a bump branch
 git checkout main && git pull
-git checkout -b release/0.6.0
-git push origin release/0.6.0
-# CI runs automatically:
-#   1. Sets all 4 version files to "0.6.0"
-#   2. Rebuilds CLI
-#   3. Commits + pushes release branch
-#   4. Tags v0.6.0 and moves latest tag
+git checkout -b bump/0.8.0
+
+# 2. Bump all 4 version files to 0.8.0
+./scripts/bump-version.sh 0.8.0   # or manually update the 4 files
+
+# 3. Open a PR into main — version-check CI verifies sync
+gh pr create --base main --title "chore: release v0.8.0"
+
+# 4. Merge the PR
+# CI on main push: detects version != 0.0.0-dev → tags v0.8.0 + moves latest tag
 ```
 
 ### How marketplace updates work
 
-- `marketplace.json` on main has `ref: "latest"` — never changes
-- `latest` tag moves on each release → users pick it up via `/plugin marketplace update`
+- Claude Code marketplace clones `main` (default branch) → reads `marketplace.json`
+- `marketplace.json` uses `"source": "./plugin"` → reads `plugin/` from that clone
+- `main` = latest release → users always get the latest stable version
+- `latest` tag is also moved by CI for any tooling that references it
 
 ### CI files
 
-- `.github/workflows/release.yml` — triggered by `push to release/**`
-- `.github/workflows/version-check.yml` — excludes `main` and `release/**`; runs on feature branches + PRs to main
+- `.github/workflows/release.yml` — triggers on push to `main`; skips if version is `0.0.0-dev` or tag already exists; creates `vX.Y.Z` + moves `latest` tag
+- `.github/workflows/version-check.yml` — runs on feature branches + PRs to `main`; verifies all 4 version files are in sync
 
 ## Current Status
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,44 +22,53 @@ See `CLAUDE.md` for the full architecture guide and Plugin vs CLI decision rules
 
 ## Branching
 
-- `main` — always deployable, version is permanently `0.0.0-dev`
-- `feat/*` — feature branches, PR into main
-- `fix/*` — bug fix branches, PR into main
-- `release/X.Y.Z` — release branches, created from main to trigger a release
+`main` is trunk and always the latest release. All changes go through PRs.
 
-Never push version bumps to main. Never push directly to main.
+| Branch | Purpose |
+|--------|---------|
+| `main` | Default branch — always stable, always versioned, what marketplace users get |
+| `feat/*` | Feature work — PR into `main`, version stays `0.0.0-dev` |
+| `fix/*` | Bug fixes — PR into `main`, version stays `0.0.0-dev` |
+| `docs/*` | Documentation — PR into `main` |
+| `bump/X.Y.Z` | Release PR — bumps version files, merges into `main` to trigger a release |
+
+**Never push directly to `main`.** Always use PRs.
 
 ## Making Changes
 
-1. Branch off main: `git checkout -b feat/my-feature`
-2. Make changes, commit
-3. Push and open a PR into main
-4. CI runs version-check on the branch and on the PR
+```bash
+git checkout main && git pull
+git checkout -b feat/my-feature
+# make changes
+git push origin feat/my-feature
+gh pr create --base main
+```
+
+CI runs `version-check.yml` on the PR — verifies all 4 version files are in sync.
 
 ## Cutting a Release
 
-Releases are fully automated via CI. You only need to push a release branch:
+A release is just a PR that bumps the version files.
 
 ```bash
 git checkout main && git pull
-git checkout -b release/0.6.0
-git push origin release/0.6.0
+git checkout -b bump/0.8.0
+
+# Bump all 4 version files manually or via script:
+./scripts/bump-version.sh 0.8.0
+
+# Open PR
+gh pr create --base main --title "chore: release v0.8.0"
 ```
 
-CI will automatically:
-1. Extract the version from the branch name (`0.6.0`)
-2. Set all 4 version files to that version
-3. Rebuild the CLI
-4. Verify versions are in sync (`scripts/check-versions.sh`)
-5. Commit and push the release branch
-6. Create and push the `v0.6.0` tag
-7. Move the `latest` tag to this commit
-
-The `latest` tag is what the marketplace uses — users get the update on their next `/plugin marketplace update`.
+Merge the PR. CI on `main` push:
+1. Reads version from `plugin/.claude-plugin/plugin.json`
+2. If version ≠ `0.0.0-dev` and tag doesn't exist yet → creates `v0.8.0` tag + moves `latest` tag
+3. Users get the update on their next `/plugin marketplace update`
 
 ### Version files
 
-There are 4 version files that must always stay in sync:
+All 4 must always be in sync. On feature branches they stay `0.0.0-dev`. On a `bump/` PR they're set to the real version.
 
 | File | Field |
 |------|-------|
@@ -68,17 +77,13 @@ There are 4 version files that must always stay in sync:
 | `plugin/package.json` | `version` + `peerDependencies.deepfield` |
 | `plugin/.claude-plugin/plugin.json` | `version` |
 
-On `main` these are all `0.0.0-dev`. CI sets them to the real version on the release branch.
-
 ## CI Workflows
 
 | Workflow | Trigger | What it does |
 |----------|---------|--------------|
-| `release.yml` | Push to `release/**` | Sets versions, builds, tags release |
-| `version-check.yml` | Push to feature branches + PRs to main | Verifies all 4 version files match |
+| `release.yml` | Push to `main` | If version ≠ `0.0.0-dev`, creates `vX.Y.Z` tag + moves `latest` |
+| `version-check.yml` | Feature branches + PRs to `main` | Verifies all 4 version files are in sync |
 
 ## Marketplace
 
-`marketplace.json` lives on `main` and never changes. It points to `ref: "latest"`, which always resolves to the most recent release tag.
-
-Users install once; updates flow automatically when they run `/plugin marketplace update`.
+`marketplace.json` uses `"source": "./plugin"`. Claude Code reads the plugin directly from `main` (the default branch). Since `main` is always the latest release, users always get stable plugin files.


### PR DESCRIPTION
PR #113 was accidentally merged into `dev` instead of `main` (base was set when `dev` was temporarily the default branch).

This PR lands the same changes onto `main` where they belong.

## Changes (from #113)
- `marketplace.json`: `git-subdir` → `"./plugin"` — fixes plugin disappearing after marketplace update
- `release.yml`: triggers on push to `main`; reads version from `plugin.json`; auto-tags if not `0.0.0-dev`
- `version-check.yml`: PRs target `main`
- `CLAUDE.md` + `CONTRIBUTING.md`: updated to document the new model

Closes #111

---
👾 @robodev.claude-M4DN