### PR TITLE
chore: release v0.8.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepfield",
-  "version": "0.0.0-dev",
+  "version": "0.8.0",
   "description": "CLI tool for AI-driven knowledge base building",
   "main": "dist/cli.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepfield",
-  "version": "0.0.0-dev",
+  "version": "0.8.0",
   "description": "AI-driven knowledge base builder for understanding brownfield projects",
   "private": true,
   "workspaces": [

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deepfield",
-  "version": "0.0.0-dev",
+  "version": "0.8.0",
   "description": "AI-driven knowledge base builder for understanding brownfield projects. Provides commands for initializing and managing deepfield/ knowledge base structure.",
   "author": {
     "name": "Deepfield Contributors",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,10 +1,10 @@
 {
   "name": "deepfield-plugin",
-  "version": "0.0.0-dev",
+  "version": "0.8.0",
   "description": "Claude Code plugin for Deepfield knowledge base builder",
   "private": true,
   "peerDependencies": {
-    "deepfield": "^0.0.0-dev"
+    "deepfield": "^0.8.0"
   },
   "dependencies": {
     "mammoth": "^1.8.0",


### PR DESCRIPTION
Bumps all 4 version files from `0.0.0-dev` to `0.8.0`.

## What's in v0.8.0

**#93 redesign epic — language-first 3-tier draft structure:**
- Phase 1+2: CLI scaffold for 3-tier structure + document templates (#102)
- Phase 3: DomainManifestSchema + `update-domain-manifest.js` + `generate-domain-links.js` (#105, #106)
- Phase 4: `deepfield-translator` agent + `/df-translate` command (#104)
- Phase 5: Bootstrap + iterate path updates to 3-tier structure (#107)
- Phase 6: Dual-track → 3-tier migration in upgrade skill (#108, #109)

**Bug fixes:**
- fix(#85): `upgrade-helpers.ts` template path (#110)
- fix(#111): marketplace plugin source — `git-subdir` → `./plugin` (#113, #114)

**CI / release workflow:**
- New model: `main` = latest release; `bump/X.Y.Z` PRs trigger CI tagging (#113)

## Release process

Merge this PR → CI (`release.yml`) detects version `0.8.0` ≠ `0.0.0-dev` → creates `v0.8.0` tag + moves `latest` tag.

---
👾 @robodev.claude-vm165