### PR TITLE
chore: release v0.8.3

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepfield",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "CLI tool for AI-driven knowledge base building",
   "main": "dist/cli.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepfield",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "AI-driven knowledge base builder for understanding brownfield projects",
   "private": true,
   "workspaces": [

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deepfield",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "AI-driven knowledge base builder for understanding brownfield projects. Provides commands for initializing and managing deepfield/ knowledge base structure.",
   "author": {
     "name": "Deepfield Contributors",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,10 +1,10 @@
 {
   "name": "deepfield-plugin",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Claude Code plugin for Deepfield knowledge base builder",
   "private": true,
   "peerDependencies": {
-    "deepfield": "^0.8.2"
+    "deepfield": "^0.8.3"
   },
   "dependencies": {
     "mammoth": "^1.8.0",


### PR DESCRIPTION
## Release v0.8.3

### What's in this release

- **feat**: `bump-version.sh` accepts explicit `X.Y.Z` version with downgrade guard (#118)
- **feat**: npm publish on release — first version to auto-publish to npm (#120)
- **fix**: `deepfield-dev` alias documented in CLAUDE.md (#120)

### First npm publish release

After merging, CI will:
1. Create tag `v0.8.3` + move `latest`
2. **Publish `deepfield@0.8.3` to npm** (first time)

Then run locally:
```bash
source ~/.zshrc
npm install -g deepfield
deepfield --version  # → 0.8.3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)