### PR TITLE
fix: use npm install instead of npm ci in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Install CLI dependencies
         if: steps.skip.outputs.skip == 'false' && steps.tag_check.outputs.skip == 'false'
         working-directory: cli
-        run: npm ci
+        run: npm install
 
       - name: Build CLI
         if: steps.skip.outputs.skip == 'false' && steps.tag_check.outputs.skip == 'false'


### PR DESCRIPTION
## Problem

Release CI failed: `npm ci` requires a `package-lock.json` but `cli/` has none.

```
npm error The npm ci command can only install with an existing package-lock.json
```

## Fix

Replace `npm ci` with `npm install` in the Install CLI dependencies step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)