### PR TITLE
chore: release v0.8.4

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepfield",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "CLI tool for AI-driven knowledge base building",
   "main": "dist/cli.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deepfield",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "AI-driven knowledge base builder for understanding brownfield projects",
   "private": true,
   "workspaces": [

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deepfield",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "AI-driven knowledge base builder for understanding brownfield projects. Provides commands for initializing and managing deepfield/ knowledge base structure.",
   "author": {
     "name": "Deepfield Contributors",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,10 +1,10 @@
 {
   "name": "deepfield-plugin",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Claude Code plugin for Deepfield knowledge base builder",
   "private": true,
   "peerDependencies": {
-    "deepfield": "^0.8.3"
+    "deepfield": "^0.8.4"
   },
   "dependencies": {
     "mammoth": "^1.8.0",


### PR DESCRIPTION
## Release v0.8.4

First release to successfully publish to npm (CI fix from #122 included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)