### PR TITLE
fix: decouple npm publish guard from git tag check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,18 +76,30 @@ jobs:
           git tag -f latest
           git push origin latest --force
 
+      - name: Check if already published to npm
+        id: npm_check
+        if: steps.skip.outputs.skip == 'false'
+        run: |
+          V="${{ steps.version.outputs.version }}"
+          if npm view "deepfield@$V" version &>/dev/null 2>&1; then
+            echo "Version $V already published to npm — skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install CLI dependencies
-        if: steps.skip.outputs.skip == 'false' && steps.tag_check.outputs.skip == 'false'
+        if: steps.skip.outputs.skip == 'false' && steps.npm_check.outputs.skip == 'false'
         working-directory: cli
         run: npm install
 
       - name: Build CLI
-        if: steps.skip.outputs.skip == 'false' && steps.tag_check.outputs.skip == 'false'
+        if: steps.skip.outputs.skip == 'false' && steps.npm_check.outputs.skip == 'false'
         working-directory: cli
         run: npm run build
 
       - name: Publish to npm
-        if: steps.skip.outputs.skip == 'false' && steps.tag_check.outputs.skip == 'false'
+        if: steps.skip.outputs.skip == 'false' && steps.npm_check.outputs.skip == 'false'
         working-directory: cli
         run: npm publish --provenance --access public
         env:


### PR DESCRIPTION
## Problem

npm publish was gated on `steps.tag_check.outputs.skip == 'false'` — the same condition as the git tagging steps. If the tag pre-existed for any reason (re-run after partial failure, tag created separately), publish was silently skipped too.

This is why 0.8.3 and 0.8.4 never published to npm.

## Fix

Separate guard for the publish steps: checks if `deepfield@X.Y.Z` is already on npm. If not published → run install/build/publish. If already published → skip gracefully.

Git tagging steps keep their existing `tag_check` guard unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)