### PR TITLE
fix: add repository.url to cli/package.json for npm provenance

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -22,6 +22,10 @@
   ],
   "author": "Deepfield Contributors",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TomazWang/deepfield"
+  },
   "engines": {
     "node": ">=18.0.0"
   },


### PR DESCRIPTION
## Problem

npm publish failed with E422:
```
Error verifying sigstore provenance bundle: package.json: "repository.url" is "",
expected to match "https://github.com/TomazWang/deepfield"
```

`cli/package.json` had no `repository` field — npm provenance infers it as empty, failing validation.

## Fix

Add `repository` to `cli/package.json`:
```json
"repository": {
  "type": "git",
  "url": "https://github.com/TomazWang/deepfield"
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)