### PR TITLE
fix: pin chalk@4 and inquirer@8 for CJS compatibility

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -31,8 +31,8 @@
   },
   "dependencies": {
     "commander": "^11.1.0",
-    "inquirer": "^9.2.12",
-    "chalk": "^5.3.0",
+    "inquirer": "^8.2.6",
+    "chalk": "^4.1.2",
     "zod": "^3.22.4",
     "fs-extra": "^11.2.0",
     "semver": "^7.6.0"


### PR DESCRIPTION
## Problem

\`deepfield --version\` crashes on install with:
\`\`\`
ERR_REQUIRE_ESM: require() of ES Module chalk/source/index.js not supported
\`\`\`

\`chalk@5\` and \`inquirer@9\` are ESM-only. The CLI builds as CJS, so \`require()\` of these modules fails at runtime on any Node version.

## Fix

- \`chalk@^4.1.2\` — last CJS version
- \`inquirer@^8.2.6\` — last CJS version

ESM migration tracked in #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)