### PR TITLE
feat(#128): migrate CLI from CJS to ESM

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -2,12 +2,13 @@
   "name": "deepfield",
   "version": "0.8.6",
   "description": "CLI tool for AI-driven knowledge base building",
+  "type": "module",
   "main": "dist/cli.js",
   "bin": {
     "deepfield": "./dist/cli.js"
   },
   "scripts": {
-    "build": "tsup src/cli.ts --format cjs --dts --clean --sourcemap && npm run copy:templates",
+    "build": "tsup src/cli.ts --format esm --dts --clean --sourcemap && npm run copy:templates",
     "copy:templates": "mkdir -p dist/templates && cp -r templates/* dist/templates/",
     "dev": "tsx src/cli.ts",
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -14,6 +14,9 @@ import {
   getSuggestedFix
 } from './core/errors.js';
 
+// ESM equivalent of __filename/__dirname
+const __filename = fileURLToPath(import.meta.url);
+
 // Get package.json for version
 const packageJsonPath = join(dirname(__filename), '../package.json');
 let version = '1.0.0';

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -1,11 +1,13 @@
 import { Command } from 'commander';
 import { pathExists, readJson, writeJson } from 'fs-extra';
-import { join } from 'path';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
 import { readFileSync } from 'fs';
-import { dirname } from 'path';
 import inquirer from 'inquirer';
 import chalk from 'chalk';
 import { scaffold, formatScaffoldResult, PermissionError } from '../core/scaffold.js';
+
+const __filename = fileURLToPath(import.meta.url);
 
 /**
  * Get current CLI version from package.json

--- a/cli/src/commands/upgrade-helpers.ts
+++ b/cli/src/commands/upgrade-helpers.ts
@@ -1,10 +1,13 @@
 import { Command } from 'commander';
 import { pathExists, readJson } from 'fs-extra';
-import { join, dirname } from 'path';
+import { join, dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
 import { homedir } from 'os';
-import { readFileSync, writeFileSync, renameSync, unlinkSync, mkdirSync } from 'fs';
+import { readFileSync, writeFileSync, renameSync, unlinkSync, mkdirSync, existsSync } from 'fs';
 import chalk from 'chalk';
 import { createBackup } from '../utils/backup.js';
+
+const __filename = fileURLToPath(import.meta.url);
 
 /**
  * Get installed plugin version from Claude Code's installed_plugins.json.
@@ -151,7 +154,7 @@ export function createApplyOpCommand(): Command {
             break;
           }
           case 'delete': {
-            if (!require('fs').existsSync(absPath)) {
+            if (!existsSync(absPath)) {
               process.stderr.write(chalk.red(`❌ File not found: ${relPath}\n`));
               process.exit(1);
             }
@@ -260,12 +263,12 @@ export function createScaffoldCrossCuttingCommand(): Command {
     .action((options) => {
       try {
         const cwd = process.cwd();
-        const deepfieldDir = require('path').resolve(cwd, options.deepfieldDir);
+        const deepfieldDir = resolve(cwd, options.deepfieldDir);
         const crossCuttingDir = join(deepfieldDir, 'drafts', 'cross-cutting');
 
         // Determine templates directory
         const templatesDir = options.templatesDir
-          ? require('path').resolve(cwd, options.templatesDir)
+          ? resolve(cwd, options.templatesDir)
           : join(dirname(dirname(__filename)), 'templates');
 
         const filesToScaffold = ['glossary.md', 'unknowns.md'];
@@ -277,11 +280,11 @@ export function createScaffoldCrossCuttingCommand(): Command {
           const targetPath = join(crossCuttingDir, filename);
           const relativePath = `drafts/cross-cutting/${filename}`;
 
-          if (require('fs').existsSync(targetPath)) {
+          if (existsSync(targetPath)) {
             process.stdout.write(`Already exists: ${relativePath}\n`);
           } else {
             const templatePath = join(templatesDir, filename);
-            if (!require('fs').existsSync(templatePath)) {
+            if (!existsSync(templatePath)) {
               process.stderr.write(chalk.red(`❌ Template not found: ${templatePath}\n`));
               process.exit(1);
             }

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -1,11 +1,14 @@
 import { Command } from 'commander';
 import { pathExists, readJson } from 'fs-extra';
 import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
 import { homedir } from 'os';
 import { readFileSync } from 'fs';
 import inquirer from 'inquirer';
 import chalk from 'chalk';
 import { createBackup } from '../utils/backup.js';
+
+const __filename = fileURLToPath(import.meta.url);
 
 /**
  * Get current CLI version. Reads from Claude Code's installed_plugins.json first

--- a/cli/src/commands/version.ts
+++ b/cli/src/commands/version.ts
@@ -1,7 +1,10 @@
 import { Command } from 'commander';
 import { readFileSync, existsSync } from 'fs';
 import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
 import chalk from 'chalk';
+
+const __filename = fileURLToPath(import.meta.url);
 
 /**
  * The three files that must carry identical version values.

--- a/cli/src/core/scaffold.ts
+++ b/cli/src/core/scaffold.ts
@@ -3,6 +3,8 @@ import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import chalk from 'chalk';
 
+const __filename = fileURLToPath(import.meta.url);
+
 /**
  * Custom error for permission issues
  */

--- a/cli/src/utils/backup.ts
+++ b/cli/src/utils/backup.ts
@@ -1,6 +1,7 @@
 import { pathExists, ensureDir, copy, readJson, remove, readdir } from 'fs-extra';
 import { join } from 'path';
 import { writeFile, readFile } from 'fs/promises';
+import { readdirSync, statSync } from 'fs';
 
 export interface BackupMeta {
   id: string;
@@ -20,7 +21,6 @@ function formatTimestamp(date: Date): string {
  * Recursively estimate folder size in bytes (best-effort, not precise)
  */
 async function estimateFolderSize(dirPath: string): Promise<number> {
-  const { readdirSync, statSync } = require('fs');
   let total = 0;
   try {
     const entries = readdirSync(dirPath, { withFileTypes: true });

--- a/cli/src/utils/check-version.ts
+++ b/cli/src/utils/check-version.ts
@@ -1,8 +1,11 @@
 import { pathExists, readFile } from 'fs-extra';
 import { readFileSync } from 'fs';
 import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
 import { homedir } from 'os';
 import semver from 'semver';
+
+const __filename = fileURLToPath(import.meta.url);
 
 /**
  * Get the current CLI version. Reads from Claude Code's installed_plugins.json first
@@ -83,7 +86,7 @@ export async function checkProjectVersion(projectPath: string): Promise<VersionC
     // Dynamically load migration list to avoid circular deps at import time
     let migrations: MigrationInfo[] = [];
     try {
-      const { getRequiredMigrations } = require('../../migrations/index.js');
+      const { getRequiredMigrations } = await import('../../migrations/index.js');
       const migs = getRequiredMigrations(projectVersion, currentVersion);
       migrations = migs.map((m: { from: string; to: string; description: string }) => ({
         from: m.from,

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "module": "node16",
+    "moduleResolution": "node16",
     "rootDir": "./src",
     "outDir": "./dist"
   },


### PR DESCRIPTION
Closes #128

## Summary

- Add `"type": "module"` to `cli/package.json` (CLI only — root and plugin packages unchanged)
- Switch tsup build from `--format cjs` → `--format esm`
- Add `cli/tsconfig.json` override with `"module": "node16"` / `"moduleResolution": "node16"` to unblock `import.meta` in DTS generation (root tsconfig had `"module": "commonjs"`)
- Replace all `__filename` / `__dirname` with `fileURLToPath(import.meta.url)` across 7 files
- Replace all inline `require('fs')` / `require('path')` calls with proper ESM imports
- Replace `require('../../migrations/index.js')` in `check-version.ts` with dynamic `await import(...)`
- `chalk` and `inquirer` are already at `^5` / `^9` on `main` (pinned back in #129, now fully compatible)

## Files changed

| File | Change |
|------|--------|
| `cli/package.json` | `"type": "module"`, `--format esm` in build script |
| `cli/tsconfig.json` | New — `node16` module/resolution override |
| `cli/src/cli.ts` | `const __filename = fileURLToPath(import.meta.url)` |
| `cli/src/commands/upgrade.ts` | Same + `fileURLToPath` import |
| `cli/src/commands/init.ts` | Same; consolidated duplicate `dirname` import |
| `cli/src/commands/version.ts` | Same |
| `cli/src/commands/upgrade-helpers.ts` | Same + `existsSync`/`resolve` imports, removed inline `require()` calls |
| `cli/src/core/scaffold.ts` | `const __filename` (import already present) |
| `cli/src/utils/backup.ts` | `import { readdirSync, statSync } from 'fs'`, removed `require('fs')` |
| `cli/src/utils/check-version.ts` | `const __filename` + `await import()` for migrations |

## Verification

Build passes: `npm run build` produces `dist/cli.js` (ESM, 72 KB) with DTS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)